### PR TITLE
Removing pip3 installation with get-pip script. (it is installed with…

### DIFF
--- a/samples/common/test_utility/cf_template/ec2-instance-panorama.yml
+++ b/samples/common/test_utility/cf_template/ec2-instance-panorama.yml
@@ -73,9 +73,6 @@ Resources:
                 cd 
                 apt-get update
                 apt-get install -y python3 python3-distutils build-essential cmake curl ca-certificates
-                curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
-                sudo python3 /tmp/get-pip.py
-                rm /tmp/get-pip.py
                 sudo pip3 install -U pip setuptools wheel
 
                 pip3 install panoramacli
@@ -120,9 +117,6 @@ Resources:
                 cd
                 sudo apt-get update
                 sudo apt-get install -y python3 python3-distutils build-essential cmake curl ca-certificates
-                curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
-                sudo python3 /tmp/get-pip.py
-                rm /tmp/get-pip.py
                 sudo pip3 install -U pip setuptools wheel
                 
                 cd


### PR DESCRIPTION
*Description of changes:*

Stopped using https://bootstrap.pypa.io/get-pip.py, as it doesn't support Python3.6 anymore.
(pip3 is installed with apt-get beforehand.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
