### PR TITLE
feat(camera validation tool): adds ability to retrieve input file from secrets manager

### DIFF
--- a/tools/camera_stream_validation/README.md
+++ b/tools/camera_stream_validation/README.md
@@ -45,30 +45,33 @@ Usage:
 * Normal validation `python3 main.py -i <input_json> -t Deploy`
 
 ```
-usage: panorama-csv-tool [-h] [-i INPUT] [-t {Register,Deploy,Remove}] [-l] [-n NUMBER]
+usage: panorama-csv-tool [-h] [-i INPUT] [-s SECRET] [-t {Register,Deploy,Remove}] [-l] [-n NUMBER] [-o OUTPUT]
 
-This is the assistance tool for AWS Panorama camera stream validation.
-In order to validate. this script will create (register) data sources if they do not yet exist. An application will then be deployed on the device to confirm that the data sources (cameras) connection can be established. Once deployment has completed and results for each data source have been returned the application will be removed from your device.
-It is important to note that the data source creation, application deployment and removal are operations that may take minutes to complete.
+This is the assistance tool for panorama camera stream validation.
+In order to validate, your data sources this script will create (register) data sources if they do not yet exist. An application will then be deployed on the device to confirm that the data sources (cameras) connection can be established. Once deployment has completed and results for each data source have been returned the application will be removed from your device. It is important to note that the data source creation, application deployment and removal are operations that may take minutes to complete.
 
 Optional arguments:
-  -h, --help            Show this help message and exit.
+  -h, --help            Show this help message and exit
   -i INPUT, --input INPUT
                         JSON file that contains the list of data source inputs.
+  -s SECRET, --secret SECRET
+                        Name of an AWS Secrets Manager secret with source inputs.
   -t {Register,Deploy,Remove}, --termination {Register,Deploy,Remove}
-                        Stop the validation workflow at the step specified.
-                        1) Register: stop the flow after all the data sources are created.
-                        2) Deploy: stop the flow after the validation application is deployed to your device.
-                        3) Remove: stop the flow after the validation application removed from your device (this is the default behavior)
+                        Stop the validation workflow at the step specified,
+                        1) Register: stop flow after camera package registered
+                        2) Deploy: stop flow after validation application deployed
+                        3) Remove: stop flow after validation application removed (this is the default behavior)
   -l, --list            Returns a list of all data sources and their validation results. This can only be used when you decide to terminate the script using the "-t Deploy" command.
   -n NUMBER, --number NUMBER
                         Specify the number of cameras to be grouped in one validation application deployment. N must be a value of 8 or less. By default the panorama media service limit is 8 data sources (default) per application deployment. This means that if your JSON has more than 8 data sources to validate we will queue multiple application deployments (this will greatly increase the time needed to complete the full validation operation).
+  -o OUTPUT, --output OUTPUT
+                        Export a JSON file which will contain the validation results. Specify the name only, e.g. "-o csvResults" will export a file named "csvResults.json".
 
 ------------------------------------------------------------------------
 Sample input
 {
     // device_id is optional, if not specified, you will be asked to select available devices
-    "device_id": "device-h3ai3ijd4w3nyi5tz5lbk5fvri" 
+    "device_id": "device-h3ai3ijd4w3nyi5tz5lbk5fvri",
     "cameras": [
         {
             "name": "my-data-source",

--- a/tools/camera_stream_validation/src/workflow/utils.py
+++ b/tools/camera_stream_validation/src/workflow/utils.py
@@ -1,17 +1,24 @@
-'''
+"""
   Copyright (c) 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
   PROPRIETARY/CONFIDENTIAL
 
   Use is subject to Panorama Beta program conditions, see README for more details
-'''
+"""
 import logging
 import itertools
+import os
 import sys
 import threading
 import time
+import boto3
+import base64
+from botocore.exceptions import ClientError
 
 from service_managers.panorama_api import Panorama
+
+DEFAULT_REGION = os.environ.get("AWS_DEFAULT_REGION")
+
 
 class Logger:
     def __init__(self):
@@ -83,3 +90,62 @@ class DeviceValidator:
             break
 
         return self.device_list[number-1]
+
+
+
+
+def get_secret(secret_name, region_name=None):
+    """
+    gets a secret from AWS Secrets Manager
+
+    :param secret_name str: Secret Name
+    :param region_name str: Optional AWS region for the client to query
+    :raises ClientError: DecryptionFailureException
+    :raises ClientError: InternalServiceErrorException
+    :raises ClientError: InvalidParameterException
+    :raises ClientError: InvalidRequestException
+    :raises ClientError: ResourceNotFoundException
+    """
+
+    logger = Logger().get_logger()
+
+    # Create a Secrets Manager client
+    client = boto3.client(
+        service_name="secretsmanager",
+        region_name=region_name if region_name is not None else DEFAULT_REGION,
+    )
+
+    try:
+        logger.info(f"Retrieving [{secret_name}] from AWS Secrets Manager")
+        get_secret_value_response = client.get_secret_value(SecretId=secret_name)
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "DecryptionFailureException":
+            # Secrets Manager can't decrypt the protected secret text using the provided KMS key.
+            # Deal with the exception here, and/or rethrow at your discretion.
+            raise e
+        elif e.response["Error"]["Code"] == "InternalServiceErrorException":
+            # An error occurred on the server side.
+            raise e
+        elif e.response["Error"]["Code"] == "InvalidParameterException":
+            # You provided an invalid value for a parameter.
+            raise e
+        elif e.response["Error"]["Code"] == "InvalidRequestException":
+            # You provided a parameter value that is not valid for the current state of the resource.
+            raise e
+        elif e.response["Error"]["Code"] == "ResourceNotFoundException":
+            # We can't find the resource that you asked for.
+            raise e
+    else:
+        # Decrypts secret using the associated KMS key.
+        # Depending on whether the secret is a string or binary, one of these fields will be populated.
+        if "SecretString" in get_secret_value_response:
+            logger.info("Secret retrieved. Reading [SecretString]")
+            secret = get_secret_value_response["SecretString"]
+            return secret
+        else:
+            logger.info("Secret retrieved. Reading [SecretBinary]")
+            decoded_binary_secret = base64.b64decode(
+                get_secret_value_response["SecretBinary"]
+            )
+            return decoded_binary_secret
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The primary change to the tool is the added ability to pull an input configuration from AWS Secrets Manager.

A secret will be used when specifying the `-s` or `--secret` argument followed by the name of the secret as follows: 
```
> python main.py -s panorama/camera_stream_validation/<SECRET_CONFIG> -o ./output.json
```

**Note: Secret should be configured using `tools/camera_stream_validation/sample/sample_input.json` before running**
**Note: <SECRET_CONFIG> replaced with the name of the location specific input config**

Usage notes now read as follows:
```
usage: panorama-csv-tool [-h] [-i INPUT] [-s SECRET] [-t {Register,Deploy,Remove}] [-l] [-n NUMBER] [-o OUTPUT]

This is the assistance tool for panorama camera stream validation.
In order to validate. your data sources this script will create (register) data sources if they do not yet exist.
An application will then be deployed on the device to confirm that the data sources (cameras) connection can be established.
Once deployment has completed and results for each data source have been returned the application will be removed from your device.
It is important to note that the data source creation, application deployment and removal are operations that may take minutes to complete.

optional arguments:
  -h, --help            show this help message and exit
  -i INPUT, --input INPUT
                        JSON file that contains the list of data source inputs.
  -s SECRET, --secret SECRET
                        Name of an AWS Secrets Manager secret with source inputs.
  -t {Register,Deploy,Remove}, --termination {Register,Deploy,Remove}
                        Stop the validation workflow at the step specified, 1) Register: stop flow after camera package registered 2) Deploy: stop flow after validation application deployed 3) Remove: stop flow after validation application removed (this is the default behavior)
  -l, --list            Returns a list of all data sources and their validation results. This can only be used when you decide to terminate the script using the "-t Deploy" command.
  -n NUMBER, --number NUMBER
                        Specify the number of cameras to be grouped in one validation application deployment. N must be a value of 8 or less. By default the panorama media service limit is 8 data sources (default) per application deployment. This means that if your JSON has more than 8 data sources to validate we will queue multiple application deployments (this will greatly increase the time needed to complete the full validation operation).
  -o OUTPUT, --output OUTPUT
                        Export a JSON file which will contain the validation results. Specify the name only, e.g. "-o csvResults" will export a file named "csvResults.json".
```

Log output will produce the following:
```
2022-07-01 21:16:16,212 - INFO:  Retrieving [panorama/camera_stream_validation/<secret_config>] from AWS Secrets Manager
2022-07-01 21:16:16,299 - INFO:  Secret retrieved. Reading [SecretString]
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
