### PR TITLE
ONNX OpenGPPU: turn on visualization and more readme

### DIFF
--- a/samples/ONNX37_opengpu/README.md
+++ b/samples/ONNX37_opengpu/README.md
@@ -100,12 +100,9 @@ The assets should look something like this
     
 
 ## graph.json
-By default we do not include hmdi pacakge and disable the edge connection between the app and hdmi node in graph.json. And thus the app will not output any visualization on screen. (The purpose is just showcasing the purpose of the edge.)
+By default we do not include hmdi pacakge and disable the edge connection between the app and hdmi node in graph.json. And thus the app will not output any visualization on screen.
 
-If one want to show the visualization on hdmi, please add:
-- the app->hdmi edge in graph.json
-- include hdmi package and hdmi node in graph.json
-- A good example will be looking at PT37_OpenGPU App.
+If one want to show the visualization on hdmi, please use graph_with_hdmi.json instead of graph.json
 
 # Debugging
 

--- a/samples/ONNX37_opengpu/README.md
+++ b/samples/ONNX37_opengpu/README.md
@@ -99,6 +99,14 @@ The assets should look something like this
 ```
     
 
+## graph.json
+By default we do not include hmdi pacakge and disable the edge connection between the app and hdmi node in graph.json. And thus the app will not output any visualization on screen. (The purpose is just showcasing the purpose of the edge.)
+
+If one want to show the visualization on hdmi, please add:
+- the app->hdmi edge in graph.json
+- include hdmi package and hdmi node in graph.json
+- A good example will be looking at PT37_OpenGPU App.
+
 # Debugging
 
 If you encounter issues with deploying from this, once the application is uploaded to the cloud, you can use the graph.json and deploy using the Panorama console as well

--- a/samples/ONNX37_opengpu/README.md
+++ b/samples/ONNX37_opengpu/README.md
@@ -102,7 +102,7 @@ The assets should look something like this
 ## graph.json
 By default we do not include hmdi pacakge and disable the edge connection between the app and hdmi node in graph.json. And thus the app will not output any visualization on screen.
 
-If one want to show the visualization on hdmi, please use graph_with_hdmi.json instead of graph.json
+If one want to show the visualization on hdmi, please use graph_with_hdmi.json instead of graph.json. Just replace graph.json with graph_with_hdmi.json 
 
 # Debugging
 

--- a/samples/ONNX37_opengpu/onnx_37_app/graphs/onnx_37_app/graph_with_hdmi.json
+++ b/samples/ONNX37_opengpu/onnx_37_app/graphs/onnx_37_app/graph_with_hdmi.json
@@ -1,0 +1,67 @@
+{
+    "nodeGraph": {
+        "envelopeVersion": "2021-01-01",
+        "packages": [
+            {
+                "name": "937544830708::onnx_37_app",
+                "version": "1.0"
+            },
+            {
+                "name": "panorama::abstract_rtsp_media_source",
+                "version": "1.0"
+            },
+            {
+                "name": "panorama::hdmi_data_sink",
+                "version": "1.0"
+            }
+        ],
+        "nodes": [
+            {
+                "name": "front_door_camera",
+                "interface": "panorama::abstract_rtsp_media_source.rtsp_v1_interface",
+                "overridable": true,
+                "launch": "onAppStart",
+                "decorator": {
+                    "title": "Camera front_door_camera",
+                    "description": "Default description for camera front_door_camera"
+                }
+            },
+            {
+                "name": "onnx_37_app_node",
+                "interface": "937544830708::onnx_37_app.onnx_37_app_interface",
+                "overridable": false,
+                "launch": "onAppStart"
+            },
+            {
+                "name": "batch_size",
+                "interface": "int32",
+                "value": 8,
+                "overridable": true,
+                "decorator": {
+                    "title": "Batch size",
+                    "description": "The batch size for model inference."
+                }
+            },
+            {
+                "name": "output_node",
+                "interface": "panorama::hdmi_data_sink.hdmi0",
+                "overridable": true,
+                "launch": "onAppStart"
+            }
+        ],
+        "edges": [
+            {
+                "producer": "front_door_camera.video_out",
+                "consumer": "onnx_37_app_node.video_in"
+            },
+            {
+                "producer": "batch_size",
+                "consumer": "onnx_37_app_node.batch_size"
+            },
+            {
+                "producer": "onnx_37_app_node.video_out",
+                "consumer": "output_node.video_in"
+            }
+        ]
+    }
+}

--- a/samples/ONNX37_opengpu/onnx_37_app/packages/028663699634-onnx_37_app-1.0/src/runonnx.py
+++ b/samples/ONNX37_opengpu/onnx_37_app/packages/028663699634-onnx_37_app-1.0/src/runonnx.py
@@ -161,8 +161,10 @@ class ObjectDetectionApp(p.node):
                 self.metrics_handler.put_metric(total_process_metric)
                 
                 # Post Process
-                # you can filter the prediction by class before nms. 
-                # ex: prediction = self.postprocess(['person']) 
+                # you can filter the prediction by a list of class_idx before nms. 
+                # we recommend to do this in the begining of this file. Don't put categories.index inside while loop.
+                # ex: filtered_classes = [ categories.index("person") ]
+                # ex: prediction = self.postprocess(filtered_classes) 
                 prediction = self.postprocess()
 
                 # uncomment the below section to draw the bounding box, drawing takes time and slow.

--- a/samples/ONNX37_opengpu/onnx_37_app/packages/028663699634-onnx_37_app-1.0/src/runonnx.py
+++ b/samples/ONNX37_opengpu/onnx_37_app/packages/028663699634-onnx_37_app-1.0/src/runonnx.py
@@ -39,7 +39,6 @@ categories = ["person", "bicycle", "car", "motorcycle", "airplane", "bus", "trai
             "microwave", "oven", "toaster", "sink", "refrigerator", "book", "clock", "vase", "scissors", "teddy bear",
             "hair drier", "toothbrush"]
 
-HUMAN_CLASS  = categories.index("person")
 class MockedFrame:
     __slots__ = ["image", "resolution"]  # <-- allowed attributes
 
@@ -163,7 +162,7 @@ class ObjectDetectionApp(p.node):
                 
                 # Post Process
                     
-                prediction = self.postprocess(filtered_classes=[HUMAN_CLASS])
+                prediction = self.postprocess()
 
                 # uncomment the below section to draw the bounding box, drawing takes time and slow.
                 visualize_metric = self.metrics_handler.get_metric('VisualizeBatchTime')
@@ -179,6 +178,7 @@ class ObjectDetectionApp(p.node):
                 self.metrics_handler.put_metric(visualize_metric)
                 
                 input_images = list()
+                self.outputs.video_out.put(input_frames)
             
             app_inference_state = self.metrics_handler.get_metric('ApplicationStatus')
             app_inference_state.add_value(float("1"), "None", 1)

--- a/samples/ONNX37_opengpu/onnx_37_app/packages/028663699634-onnx_37_app-1.0/src/runonnx.py
+++ b/samples/ONNX37_opengpu/onnx_37_app/packages/028663699634-onnx_37_app-1.0/src/runonnx.py
@@ -161,7 +161,8 @@ class ObjectDetectionApp(p.node):
                 self.metrics_handler.put_metric(total_process_metric)
                 
                 # Post Process
-                    
+                # you can filter the prediction by class before nms. 
+                # ex: prediction = self.postprocess(['person']) 
                 prediction = self.postprocess()
 
                 # uncomment the below section to draw the bounding box, drawing takes time and slow.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Turn on the visualization part. And standardize the post-processing threshold and filter.
- More readme. Telling that this app does not include hdmi output.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
