### PR TITLE
Pytorch Yolov5: Add synchronize() to measure time, and remove filtering class

### DIFF
--- a/samples/PT37_opengpu/yolov5s_pt37_app/graphs/yolov5s_pt37_app/graph.json
+++ b/samples/PT37_opengpu/yolov5s_pt37_app/graphs/yolov5s_pt37_app/graph.json
@@ -42,7 +42,11 @@
                 "name": "model_batch_size",
                 "value": 1,
                 "interface": "int32",
-                "overridable": true
+                "overridable": true,
+                "decorator": {
+                    "title": "Batch size",
+                    "description": "The batch size for model inference. Batch size 8 for Jetson Xavier AGX; batch size 2 for Jetson Xavier NX module."
+                }
             }
         ],
         "edges": [

--- a/samples/PT37_opengpu/yolov5s_pt37_app/packages/028663699634-yolov5s_pt37_app-1.0/src/app/app_fp16.py
+++ b/samples/PT37_opengpu/yolov5s_pt37_app/packages/028663699634-yolov5s_pt37_app-1.0/src/app/app_fp16.py
@@ -44,6 +44,13 @@ class ObjectDetectionApp(p.node):
         self.yolov5s = torch.jit.load('/panorama/yolov5s_model/yolov5s_half.pt', map_location=torch.device(self.device))
         self.num_classes = 80
 
+        # NMS: set the threshold and filtered class
+        self.conf_thres = 0.5
+        self.iou_thres = 0.45
+        # you can filter the prediction by class before nms.
+        # ex: filtered_classes = categories.index("person")
+        self.filtered_classes = None
+
         # Note: These are CW dimensions. Change as necessary
         dimensions = list()
         stage_dimension = {'Name': 'Stage', 'Value': 'Gamma'}
@@ -100,6 +107,8 @@ class ObjectDetectionApp(p.node):
                 # e.g. with batch size 4, have [4, 1, 3, 640, 640] squeezed into [4, 3, 640, 640]
                 pre_processed_images = torch.squeeze(pre_processed_images, dim=1)
 
+                # PyTorch CUDA is asynchronous.
+                # For time measurement, call synchronize() to wait for the prior GPU operation's completion.
                 torch.cuda.synchronize()
                 preprocessing_metric.add_time_as_milliseconds(1)
                 self.metrics_handler.put_metric(preprocessing_metric)
@@ -107,6 +116,9 @@ class ObjectDetectionApp(p.node):
                 # Inference
                 total_inference_metric = self.metrics_handler.get_metric('TotalInferenceTime')
                 pred = self.yolov5s(pre_processed_images)[3] # 1, 25200, 85
+
+                # PyTorch CUDA is asynchronous.
+                # For time measurement, call synchronize() to wait for the prior GPU operation's completion.
                 torch.cuda.synchronize()
                 total_inference_metric.add_time_as_milliseconds(1)
                 self.metrics_handler.put_metric(total_inference_metric)
@@ -118,30 +130,27 @@ class ObjectDetectionApp(p.node):
                 # Post Process
                 postprocess_metric = self.metrics_handler.get_metric('PostProcessBatchTime')
 
-                conf_thres = 0.5
-                iou_thres = 0.45
-                # you can filter the prediction by class before nms.
-                # ex: filtered_classes = categories.index("person")
-                filtered_classes = None
-                pred = img_utils.non_max_suppression(pred, conf_thres = conf_thres,
-                       iou_thres=iou_thres, classes=filtered_classes)
+                pred = img_utils.non_max_suppression(pred, conf_thres = self.conf_thres,
+                       iou_thres=self.iou_thres, classes=self.filtered_classes)
 
-                output = []
+                scaled_pred = []
                 for det in pred:
                     if det is not None and len(det):
                         det[:, :4] = img_utils.scale_coords(pre_processed_images[0].shape[1:],
                                      det[:, :4], input_images_batch[0].shape).round()
-                        output.append(det.cpu().detach().numpy())
+                        scaled_pred.append(det.cpu().detach().numpy())
                     else:
-                        output.append(np.array([]))
+                        scaled_pred.append(np.array([]))
 
+                # PyTorch CUDA is asynchronous.
+                # For time measurement, call synchronize() to wait for the prior GPU operation's completion.
                 torch.cuda.synchronize()
                 postprocess_metric.add_time_as_milliseconds(1)
                 self.metrics_handler.put_metric(postprocess_metric)
 
                 visualize_metric = self.metrics_handler.get_metric('VisualizeBatchTime')
                 # Draw rectangles and labels on the original image
-                for image_idx, det_results in enumerate(output):
+                for image_idx, det_results in enumerate(scaled_pred):
                     for box_idx, bbox in enumerate(det_results):
                         bbox = bbox.tolist()
                         coord = bbox[:4]

--- a/samples/PT37_opengpu/yolov5s_pt37_app/packages/028663699634-yolov5s_pt37_app-1.0/src/app/app_fp16.py
+++ b/samples/PT37_opengpu/yolov5s_pt37_app/packages/028663699634-yolov5s_pt37_app-1.0/src/app/app_fp16.py
@@ -47,7 +47,9 @@ class ObjectDetectionApp(p.node):
         # NMS: set the threshold and filtered class
         self.conf_thres = 0.5
         self.iou_thres = 0.45
-        # you can filter the prediction by class before nms.
+
+        # classes you want to detect. None as disable filter.
+        # this will filter out other classes before nms.
         # ex: filtered_classes = categories.index("person")
         self.filtered_classes = None
 
@@ -107,8 +109,8 @@ class ObjectDetectionApp(p.node):
                 # e.g. with batch size 4, have [4, 1, 3, 640, 640] squeezed into [4, 3, 640, 640]
                 pre_processed_images = torch.squeeze(pre_processed_images, dim=1)
 
-                # PyTorch CUDA is asynchronous.
-                # For time measurement, call synchronize() to wait for the prior GPU operation's completion.
+                # PyTorch CUDA is asynchronous: call synchronize() to wait for the prior GPU operation's completion.
+                # This can be disabled if no need to do time measurement.
                 torch.cuda.synchronize()
                 preprocessing_metric.add_time_as_milliseconds(1)
                 self.metrics_handler.put_metric(preprocessing_metric)
@@ -117,8 +119,8 @@ class ObjectDetectionApp(p.node):
                 total_inference_metric = self.metrics_handler.get_metric('TotalInferenceTime')
                 pred = self.yolov5s(pre_processed_images)[3] # 1, 25200, 85
 
-                # PyTorch CUDA is asynchronous.
-                # For time measurement, call synchronize() to wait for the prior GPU operation's completion.
+                # PyTorch CUDA is asynchronous: call synchronize() to wait for the prior GPU operation's completion.
+                # This can be disabled if no need to do time measurement.
                 torch.cuda.synchronize()
                 total_inference_metric.add_time_as_milliseconds(1)
                 self.metrics_handler.put_metric(total_inference_metric)
@@ -142,8 +144,8 @@ class ObjectDetectionApp(p.node):
                     else:
                         scaled_pred.append(np.array([]))
 
-                # PyTorch CUDA is asynchronous.
-                # For time measurement, call synchronize() to wait for the prior GPU operation's completion.
+                # PyTorch CUDA is asynchronous: call synchronize() to wait for the prior GPU operation's completion.
+                # This can be disabled if no need to do time measurement.
                 torch.cuda.synchronize()
                 postprocess_metric.add_time_as_milliseconds(1)
                 self.metrics_handler.put_metric(postprocess_metric)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Pytorch operations are asynchronous (referring to [this](https://pytorch.org/docs/master/notes/cuda.html#asynchronous-execution)), and it requires to do `torch.cuda.synchronize()` to correctly measure the total execution time.

Also we remove class filtering in postprocessing (NMS) by default.

TODO: It'd better to have app and metrics collection into separate class.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
