### PR TITLE
App Status Incorrect Due to Process Can Not be Joined

### DIFF
--- a/samples/ONNX2TRT_opengpu/onnx2trt_app/packages/201125699002-onnx2trt_app-1.0/src/cw_metrics/cw_post_metric.py
+++ b/samples/ONNX2TRT_opengpu/onnx2trt_app/packages/201125699002-onnx2trt_app-1.0/src/cw_metrics/cw_post_metric.py
@@ -143,6 +143,9 @@ class MetricsHandler:
     def terminate(self):
         self.post_process.terminate()
 
+    def kill(self):
+        self.post_process.kill()
+
     def get_metric(self, name):
         return self.metrics_factory.get_metric_object(name)
 

--- a/samples/ONNX2TRT_opengpu/onnx2trt_app/packages/201125699002-onnx2trt_app-1.0/src/tensorrt_pytorch_panorama.py
+++ b/samples/ONNX2TRT_opengpu/onnx2trt_app/packages/201125699002-onnx2trt_app-1.0/src/tensorrt_pytorch_panorama.py
@@ -158,4 +158,5 @@ if __name__ == '__main__':
         app.run()
     except Exception as err:
         log.exception('App Did not Start {}'.format(err))
+        app.metrics_handler.kill()
         sys.exit(1)

--- a/samples/ONNX37_opengpu/onnx_37_app/packages/028663699634-onnx_37_app-1.0/src/cw_post_metric.py
+++ b/samples/ONNX37_opengpu/onnx_37_app/packages/028663699634-onnx_37_app-1.0/src/cw_post_metric.py
@@ -152,6 +152,9 @@ class MetricsHandler:
     def terminate(self):
         self.post_process.terminate()
 
+    def kill(self):
+        self.post_process.kill()
+
     def get_metric(self, name):
         return self.metrics_factory.get_metric_object(name)
 

--- a/samples/ONNX37_opengpu/onnx_37_app/packages/028663699634-onnx_37_app-1.0/src/runonnx.py
+++ b/samples/ONNX37_opengpu/onnx_37_app/packages/028663699634-onnx_37_app-1.0/src/runonnx.py
@@ -193,5 +193,6 @@ if __name__ == '__main__':
     except Exception as err:
         log.exception('App Did not Start {}'.format(err))
         log.exception(traceback.format_exc())
+        app.metrics_handler.kill()
         sys.exit(1)
 

--- a/samples/PT37_opengpu/yolov5s_pt37_app/packages/028663699634-yolov5s_pt37_app-1.0/src/app/app_fp16.py
+++ b/samples/PT37_opengpu/yolov5s_pt37_app/packages/028663699634-yolov5s_pt37_app-1.0/src/app/app_fp16.py
@@ -179,4 +179,5 @@ if __name__ == '__main__':
         app.run()
     except Exception as err:
         log.exception('App did not Start {}'.format(err))
+        app.metrics_handler.kill()
         sys.exit(1)

--- a/samples/PT37_opengpu/yolov5s_pt37_app/packages/028663699634-yolov5s_pt37_app-1.0/src/app/cw_post_metric.py
+++ b/samples/PT37_opengpu/yolov5s_pt37_app/packages/028663699634-yolov5s_pt37_app-1.0/src/app/cw_post_metric.py
@@ -152,6 +152,9 @@ class MetricsHandler:
     def terminate(self):
         self.post_process.terminate()
 
+    def kill(self):
+        self.post_process.kill()
+
     def get_metric(self, name):
         return self.metrics_factory.get_metric_object(name)
 

--- a/samples/TF37_opengpu/tf2_4_trt_app/packages/028663699634-tf2_4_trt_app-1.0/src/app.py
+++ b/samples/TF37_opengpu/tf2_4_trt_app/packages/028663699634-tf2_4_trt_app-1.0/src/app.py
@@ -135,4 +135,5 @@ if __name__ == '__main__':
         app.run()
     except Exception as err:
         log.exception("App did not start {}".format(err))
+        app.metrics_handler.kill()
         sys.exit(1)

--- a/samples/TF37_opengpu/tf2_4_trt_app/packages/028663699634-tf2_4_trt_app-1.0/src/cw_post_metric.py
+++ b/samples/TF37_opengpu/tf2_4_trt_app/packages/028663699634-tf2_4_trt_app-1.0/src/cw_post_metric.py
@@ -152,6 +152,9 @@ class MetricsHandler:
     def terminate(self):
         self.post_process.terminate()
 
+    def kill(self):
+        self.post_process.kill()
+
     def get_metric(self, name):
         return self.metrics_factory.get_metric_object(name)
 


### PR DESCRIPTION
*Issue #, if available:*
The OpenGPU apps will stuck when  apps crash due to process cannot be join. And causing the app status showing running on the console.

*Description of changes:*
- Stop the process before the app exit.
- Reduce the docker image size of ONNX and PT.
- All four changed apps are tested.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
