### PR TITLE
Add JP4.6 Patch into OpenGPU apps.

### DIFF
--- a/samples/ONNX2TRT_opengpu/dependencies/docker_jp462/Dockerfile
+++ b/samples/ONNX2TRT_opengpu/dependencies/docker_jp462/Dockerfile
@@ -28,6 +28,7 @@ RUN CUDAPKG=$(echo $CUDA | sed 's/\./-/'); \
 	cuda-nvtx-$CUDAPKG \
 	cuda-libraries-dev-$CUDAPKG \
 	cuda-minimal-build-$CUDAPKG \
+    cuda-command-line-tools-$CUDAPKG \
     libcudnn8 \
     tensorrt \
     && rm -rf /var/lib/apt/lists/* \
@@ -37,6 +38,42 @@ RUN CUDAPKG=$(echo $CUDA | sed 's/\./-/'); \
     && rm -rf /usr/lib/aarch64-linux-gnu/libnvinfer_plugin_static.a \
     && rm -rf /usr/lib/aarch64-linux-gnu/*static*
     #Remove static libraries to save space
+
+#################################
+#      TensorRT For Python      #
+#################################
+
+RUN apt-get update -y \
+    && apt-get install -y python3-libnvinfer-dev zip \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+# patching for JP4.6.2 for Jetson NX 16GB
+COPY TensorRT8.2FixforJetsonNX16GB.zip .
+RUN mkdir /jp46_patch && mv TensorRT8.2FixforJetsonNX16GB.zip /jp46_patch \
+    && cd /jp46_patch && unzip TensorRT8.2FixforJetsonNX16GB.zip 
+
+RUN dpkg -i /jp46_patch/libnvinfer8_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/libnvinfer-dev_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/libnvinfer-plugin8_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/libnvinfer-plugin-dev_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/libnvonnxparsers8_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/libnvonnxparsers-dev_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/libnvparsers8_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/libnvparsers-dev_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/libnvinfer-bin_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/libnvinfer-doc_8.2.1-1+cuda10.2_all.deb \
+    && dpkg -i /jp46_patch/libnvinfer-samples_8.2.1-1+cuda10.2_all.deb \
+    && dpkg -i /jp46_patch/tensorrt_8.2.1.9-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/python3-libnvinfer_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/python3-libnvinfer-dev_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/graphsurgeon-tf_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/uff-converter-tf_8.2.1-1+cuda10.2_arm64.deb \
+    && rm -rf /usr/local/cuda-$CUDA/targets/aarch64-linux/lib/*.a \
+    && rm -rf /usr/lib/aarch64-linux-gnu/libnvinfer_static.a \
+    && rm -rf /usr/lib/aarch64-linux-gnu/libnvinfer_plugin_static.a \
+    && rm -rf /usr/lib/aarch64-linux-gnu/*static* \
+    && rm -r /jp46_patch
 
 
 ENV LIBRARY_PATH /usr/local/cuda/lib64/stubs
@@ -131,15 +168,6 @@ RUN python3.6 -m pip install --no-cache-dir pycuda==2020.1 six
 RUN python3.6 -m pip install --no-cache-dir opencv-python
 
 
-#################################
-#      TensorRT For Python      #
-#################################
-
-RUN apt-get update -y \
-    && apt-get install python3-libnvinfer-dev -y \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
-
 ######################
 # torchvision 0.10.0 #
 ######################
@@ -195,8 +223,10 @@ RUN echo "patching _GLIBCXX_USE_CXX11_ABI in ${TORCH_CMAKE_CONFIG}" && \
 
 
 ARG PYTHON_EGG_CACHE="/panorama/.cache"
-RUN python3.6 -c "import torch; import torchvision"
+RUN nm -D /usr/lib/aarch64-linux-gnu/libnvinfer.so | grep tensorrt_version
+RUN python3.6 -c "import torch; import torchvision;"
 RUN python3.6 -m pip cache purge
+
 
 RUN mkdir -p /tmp/test && \
     mkdir -p /panorama/test && \

--- a/samples/ONNX2TRT_opengpu/dependencies/docker_jp462/Dockerfile
+++ b/samples/ONNX2TRT_opengpu/dependencies/docker_jp462/Dockerfile
@@ -1,11 +1,11 @@
 FROM public.ecr.aws/panorama/panorama-application:latest
 
 # Lets use Python3.6
-RUN python3.7 -m pip uninstall -y numpy
-RUN rm /usr/bin/python3
-RUN ln -s /usr/bin/python3.6 /usr/bin/python3
+RUN python3.7 -m pip uninstall -y numpy \
+    && rm /usr/bin/python3 \
+    && ln -s /usr/bin/python3.6 /usr/bin/python3 \
+    && apt-get remove -y python3.7
 
-RUN apt-get remove -y python3.7
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg2 \
     ca-certificates
@@ -20,48 +20,24 @@ RUN apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-pu
 
 
 #
-# install prerequisites - https://docs.nvidia.com/deeplearning/frameworks/install-tf-jetson-platform/index.html#prereqs
-#
-RUN apt-get update && \
- apt-get install -y --no-install-recommends \
-       python3-pip \
-       python3-dev \
-       gfortran \
-       build-essential \
-       liblapack-dev \
-       libblas-dev \
-       libhdf5-serial-dev \
-       hdf5-tools \
-       libhdf5-dev \
-       zlib1g-dev \
-       zip \
-       libjpeg8-dev \
-       wget
-
-#RUN mkdir -p /usr/lib/python3.6/lib-dynload
-#RUN cp /usr/lib/python3.7/lib-dynload/panoramasdk.so /usr/lib/python3.6/lib-dynload/panoramasdk.so
-
-#
 # Install Cuda, cuDNN, TensorRT
-#
+# nvtx is required my pytorch
 RUN CUDAPKG=$(echo $CUDA | sed 's/\./-/'); \
     apt-get update && apt-get install -y --no-install-recommends \
 	cuda-libraries-$CUDAPKG \
 	cuda-nvtx-$CUDAPKG \
 	cuda-libraries-dev-$CUDAPKG \
 	cuda-minimal-build-$CUDAPKG \
-	cuda-license-$CUDAPKG \
-	cuda-command-line-tools-$CUDAPKG \
     libcudnn8 \
     tensorrt \
     && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
+    && apt-get clean \
+    && rm -rf /usr/local/cuda-$CUDA/targets/aarch64-linux/lib/*.a \
+    && rm -rf /usr/lib/aarch64-linux-gnu/libnvinfer_static.a \
+    && rm -rf /usr/lib/aarch64-linux-gnu/libnvinfer_plugin_static.a \
+    && rm -rf /usr/lib/aarch64-linux-gnu/*static*
+    #Remove static libraries to save space
 
-#Remove static libraries to save space
-RUN rm -rf /usr/local/cuda-$CUDA/targets/aarch64-linux/lib/*.a
-RUN rm -rf /usr/local/cuda-$CUDA/lib64/*.a
-RUN rm -rf /usr/lib/aarch64-linux-gnu/libnvinfer_static.a
-RUN rm -rf /usr/lib/aarch64-linux-gnu/libnvinfer_plugin_static.a
 
 ENV LIBRARY_PATH /usr/local/cuda/lib64/stubs
 
@@ -95,223 +71,118 @@ ENV PATH /usr/local/cuda-$CUDA/bin:/usr/local/cuda/bin:${PATH}
 ENV LD_LIBRARY_PATH /usr/local/cuda-$CUDA/targets/aarch64-linux/lib:${LD_LIBRARY_PATH}
 
 ENV DEBIAN_FRONTEND=noninteractive
-ARG HDF5_DIR="/usr/lib/aarch64-linux-gnu/hdf5/serial/"
-ARG MAKEFLAGS=-j$(nproc)
+# ARG HDF5_DIR="/usr/lib/aarch64-linux-gnu/hdf5/serial/"
+# ARG MAKEFLAGS=-j$(nproc)
 
-RUN printenv
+# RUN printenv
 
-#
-# Install tensorflow dependencies
-#
+######################
+#      Pytorch       #
+######################
+
+# install prerequisites - https://elinux.org/Jetson_Zoo#PyTorch_.28Caffe2.29
+# python3 dev is for numpy
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        libopenblas-base \
+        libopenmpi-dev \
+        libomp-dev \
+        python3-pip \
+        python3-dev \
+        wget \
+        && rm -rf /var/lib/apt/lists/* \
+        && apt-get clean
+
+ARG TORCH_WHL=torch-1.10.0-cp36-cp36m-linux_aarch64.whl
+RUN wget https://panorama-starter-kit.s3.amazonaws.com/public/v2/opengpusamples/TRT_Sample/Docker/torch-1.10.0-cp36-cp36m-linux_aarch64.whl \
+    && python3.6 -m pip install --pre --verbose ${TORCH_WHL} \
+    && rm ${TORCH_WHL}
+
+
+##################
+# Install Pycuda #
+##################
 RUN python3.6 -m pip install --no-cache-dir setuptools Cython wheel
-RUN python3.6 -m pip install --no-cache-dir --verbose numpy
-#RUN python3.6 -m pip install --no-cache-dir --verbose h5py==2.10.0
-#RUN python3.6 -m pip install --no-cache-dir --verbose future==0.18.2 mock==3.0.5 h5py==2.10.0 keras_preprocessing==1.1.1 keras_applications==1.0.8 gast==0.2.2 futures protobuf pybind11
+RUN python3.6 -m pip install --no-cache-dir numpy
 
-#
-# TensorFlow 2.4. See build instructions for building tensorflow wheel here: https://apivovarov.medium.com/run-tensorflow-2-object-detection-models-with-tensorrt-on-jetson-xavier-using-tf-c-api-e34548818ac6
-#
-#COPY tensorflow-2.4.4-cp36-cp36m-linux_aarch64.whl .
-#ARG TENSORFLOW_WHL=tensorflow-2.4.4-cp36-cp36m-linux_aarch64.whl
-
-#RUN apt-get update && \
-#    apt-get install -y --no-install-recommends wget
-
-#RUN python3.6 -m pip install --pre --verbose ${TENSORFLOW_WHL} && \
-#    rm ${TENSORFLOW_WHL}
-
-#
-# PyCUDA
-#
 ENV PATH="/usr/local/cuda/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/usr/local/cuda/lib64:${LD_LIBRARY_PATH}"
 RUN echo "$PATH" && echo "$LD_LIBRARY_PATH"
 
+# upgrade pip for opencv and other libs
 RUN python3.6 -m pip  install --upgrade pip
-
-RUN python3.6 -m pip install --no-cache-dir --verbose pycuda six
+RUN python3.6 -m pip install --no-cache-dir pycuda==2020.1 six
 
 #
 # Run ld config
 #
-RUN ldconfig
+# RUN ldconfig
 
-#
-# Set environment variables
-# Note: These environment variables don't get persisted for runtime.
-#
-ENV NVIDIA_VISIBLE_DEVICES all
-ENV NVIDIA_DRIVER_CAPABILITIES all
+    
 
-CMD [ "/bin/bash" ]
+######################
+#      OpenCV        #
+######################
+
+# RUN apt-get update -y && apt-get install -y libglib2.0-0 \
+#     && rm -rf /var/lib/apt/lists/* \
+#     && apt-get clean
+
+RUN python3.6 -m pip install --no-cache-dir opencv-python
 
 
-RUN wget https://panorama-starter-kit.s3.amazonaws.com/public/v2/opengpusamples/TRT_Sample/Docker/torch-1.10.0-cp36-cp36m-linux_aarch64.whl
-ARG TORCH_WHL=torch-1.10.0-cp36-cp36m-linux_aarch64.whl
+#################################
+#      TensorRT For Python      #
+#################################
 
-
-RUN python3.6 -m pip install --pre --verbose ${TORCH_WHL} && \
-    rm ${TORCH_WHL}
-
-RUN apt-get update && apt-get install -y libglib2.0-0
-#RUN python3.6 -m pip install opencv-python boto3
-RUN rm /usr/bin/python3
-RUN ln -s /usr/bin/python3.6 /usr/bin/python3
-#
-# OpenCV - https://github.com/mdegans/nano_build_opencv/blob/master/build_opencv.sh
-#
-WORKDIR /opt
-
-ARG OPENCV_VERSION="4.4.0"
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        build-essential \
-	   gfortran \
-        cmake \
-        git \
-	   file \
-	   tar \
-	   python3-pip \
-	   python3-dev \
-	   python3-distutils \
-	   python3-setuptools \
-        libatlas-base-dev \
-        libavcodec-dev \
-        libavformat-dev \
-        libavresample-dev \
-        libcanberra-gtk3-module \
-        libdc1394-22-dev \
-        libeigen3-dev \
-        libglew-dev \
-        libgstreamer-plugins-base1.0-dev \
-        libgstreamer-plugins-good1.0-dev \
-        libgstreamer1.0-dev \
-        libgtk-3-dev \
-        libjpeg-dev \
-        libjpeg8-dev \
-        libjpeg-turbo8-dev \
-        liblapack-dev \
-        liblapacke-dev \
-        libopenblas-dev \
-        libpng-dev \
-        libpostproc-dev \
-        libswscale-dev \
-        libtbb-dev \
-        libtbb2 \
-        libtesseract-dev \
-        libtiff-dev \
-        libv4l-dev \
-        libxine2-dev \
-        libxvidcore-dev \
-        libx264-dev \
-	   libgtkglext1 \
-	   libgtkglext1-dev \
-        pkg-config \
-        qv4l2 \
-        v4l-utils \
-        v4l2ucp \
-        zlib1g-dev \
+RUN apt-get update -y \
+    && apt-get install python3-libnvinfer-dev -y \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
-# OpenCV looks for the cuDNN version in cudnn_version.h, but it's been renamed to cudnn_version_v8.h
-RUN ln -s /usr/include/aarch64-linux-gnu/cudnn_version_v8.h /usr/include/aarch64-linux-gnu/cudnn_version.h
+######################
+# torchvision 0.10.0 #
+######################
+# There are two ways to install it. Either install if from source or install the 
+# prebuilt whl we provide.
 
-RUN git clone --depth 1 --branch ${OPENCV_VERSION} https://github.com/opencv/opencv.git && \
-    git clone --depth 1 --branch ${OPENCV_VERSION} https://github.com/opencv/opencv_contrib.git && \
-    cd opencv && \
-    mkdir build && \
-    cd build && \
-    cmake \
-        -D CPACK_BINARY_DEB=ON \
-	   -D BUILD_EXAMPLES=OFF \
-        -D BUILD_opencv_python2=OFF \
-        -D BUILD_opencv_python3=ON \
-	   -D BUILD_opencv_java=OFF \
-        -D CMAKE_BUILD_TYPE=RELEASE \
-        -D CMAKE_INSTALL_PREFIX=/usr/local \
-        -D CUDA_ARCH_BIN=5.3,6.2,7.2 \
-        -D CUDA_ARCH_PTX= \
-        -D CUDA_FAST_MATH=ON \
-        -D CUDNN_INCLUDE_DIR=/usr/include/aarch64-linux-gnu \
-        -D EIGEN_INCLUDE_PATH=/usr/include/eigen3 \
-	   -D WITH_EIGEN=ON \
-        -D ENABLE_NEON=ON \
-        -D OPENCV_DNN_CUDA=ON \
-        -D OPENCV_ENABLE_NONFREE=ON \
-        -D OPENCV_EXTRA_MODULES_PATH=/opt/opencv_contrib/modules \
-        -D OPENCV_GENERATE_PKGCONFIG=ON \
-        -D WITH_CUBLAS=ON \
-        -D WITH_CUDA=ON \
-        -D WITH_CUDNN=ON \
-        -D WITH_GSTREAMER=ON \
-        -D WITH_LIBV4L=ON \
-        -D WITH_OPENGL=ON \
-	   -D WITH_OPENCL=OFF \
-	   -D WITH_IPP=OFF \
-        -D WITH_TBB=ON \
-	   -D BUILD_TIFF=ON \
-	   -D BUILD_PERF_TESTS=OFF \
-	   -D BUILD_TESTS=OFF \
-	   ../
-
-RUN cd opencv/build && make -j$(nproc)
-RUN cd opencv/build && make install
-RUN cd opencv/build && make package
-
-RUN cd opencv/build && tar -czvf OpenCV-${OPENCV_VERSION}-aarch64.tar.gz *.deb
-
-
-# TesnorRT
-RUN apt-get install tensorrt -y
-
-RUN apt-get update -y
-RUN apt-get install libopenblas-base libopenmpi-dev -y
-# COPY test.py /panorama/test.py
-# COPY yolov5s.engine /panorama/yolov5s.engine
-
-
-#RUN apt-get install python3.7 python3.7-dev -y
-RUN apt-get install python3-libnvinfer-dev -y
-
-#RUN cp -r /usr/lib/python3.6/dist-packages/tensorrt /usr/lib/python3.7/dist-packages/
-#RUN cp -r /usr/lib/python3.6/dist-packages/tensorrt-7.1.3.0.dist-info/ /usr/lib/python3.7/dist-packages/
-
-
-#
-# torchvision 0.10.0
-#
-ARG FORCE_CUDA=1
-ARG TORCHVISION_VERSION=v0.10.0
 ARG PILLOW_VERSION=pillow<9.0.1
-ARG TORCH_CUDA_ARCH_LIST="5.3;6.2;7.2"
-RUN printenv && echo "torchvision version = $TORCHVISION_VERSION" && echo "pillow version = $PILLOW_VERSION" && echo "TORCH_CUDA_ARCH_LIST = $TORCH_CUDA_ARCH_LIST"
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-          git \
-          build-essential \
-            libjpeg-dev \
-          zlib1g-dev \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
-RUN git clone -b ${TORCHVISION_VERSION} https://github.com/pytorch/vision torchvision
-RUN python3.6 -m pip install "${PILLOW_VERSION}"
-RUN cd torchvision && \
-    python3.6 setup.py install && \
-    cd ../  && \
-    rm -rf torchvision
-# note:  this was used on older torchvision versions (~0.4) to workaround a bug,
-#        but has since started causing another bug as of torchvision 0.11.1
-# pip3 install --no-cache-dir "${PILLOW_VERSION}"
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-          software-properties-common \
-          apt-transport-https \
-          ca-certificates \
-          gnupg \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
+RUN python3.6 -m pip install --no-cache-dir "${PILLOW_VERSION}"
+
+# # Install from source:
+# ARG FORCE_CUDA=1
+# ARG TORCHVISION_VERSION=v0.10.0
+# ARG TORCH_CUDA_ARCH_LIST="5.3;6.2;7.2"
+# RUN printenv && echo "torchvision version = $TORCHVISION_VERSION" && echo "pillow version = $PILLOW_VERSION" && echo "TORCH_CUDA_ARCH_LIST = $TORCH_CUDA_ARCH_LIST"
+# RUN apt-get update && \
+#     apt-get install -y --no-install-recommends \
+#           git \
+#           build-essential \
+#             libjpeg-dev \
+#           zlib1g-dev \
+#     && rm -rf /var/lib/apt/lists/* \
+#     && apt-get clean
+# RUN git clone -b ${TORCHVISION_VERSION} https://github.com/pytorch/vision torchvision
+# RUN cd torchvision && \
+#     python3.6 setup.py install && \
+#     cd ../  && \
+#     rm -rf torchvision
+
+# # Install from whl (we prebuilt this)
+ARG TORCHVISION_WHL=torchvision-0.10.0a0+300a8a4-cp36-cp36m-linux_aarch64.whl
+RUN wget https://panorama-starter-kit.s3.amazonaws.com/public/v2/opengpusamples/TRT_Sample/Docker/torchvision-0.10.0a0%2B300a8a4-cp36-cp36m-linux_aarch64.whl -O ${TORCHVISION_WHL} \
+    && python3.6 -m pip install --pre --verbose ${TORCHVISION_WHL} && rm ${TORCHVISION_WHL}
+
+# # note:  this was used on older torchvision versions (~0.4) to workaround a bug,
+# #       but has since started causing another bug as of torchvision 0.11.1
+# RUN apt-get update && \
+#     apt-get install -y --no-install-recommends \
+#           software-properties-common \
+#           apt-transport-https \
+#           ca-certificates \
+#           gnupg \
+#     && rm -rf /var/lib/apt/lists/* \
+#     && apt-get clean
 
 # patch for https://github.com/pytorch/pytorch/issues/45323
 ARG TORCH_CMAKE_CONFIG=/usr/local/lib/python3.6/dist-packages/torch/share/cmake/Torch/TorchConfig.cmake
@@ -322,13 +193,13 @@ RUN echo "patching _GLIBCXX_USE_CXX11_ABI in ${TORCH_CMAKE_CONFIG}" && \
     echo "contents of ${TORCH_CMAKE_CONFIG} after patching..." && \
     cat ${TORCH_CMAKE_CONFIG}
 
-RUN python3.6 -m pip install -U matplotlib pyyaml scipy tqdm pandas requests seaborn
 
 ARG PYTHON_EGG_CACHE="/panorama/.cache"
 RUN python3.6 -c "import torch; import torchvision"
+RUN python3.6 -m pip cache purge
 
-RUN mkdir -p /tmp/test
-RUN mkdir -p /panorama/test
-RUN ln -s /tmp/test /panorama/test
-RUN mkdir -p /panorama/storage-test
-RUN ln -s /panorama/storage-test /opt/aws/panorama/storage/test
+RUN mkdir -p /tmp/test && \
+    mkdir -p /panorama/test && \
+    ln -s /tmp/test /panorama/test && \ 
+    mkdir -p /panorama/storage-test && \
+    ln -s /panorama/storage-test /opt/aws/panorama/storage/test

--- a/samples/ONNX2TRT_opengpu/dependencies/docker_jp462/Dockerfile
+++ b/samples/ONNX2TRT_opengpu/dependencies/docker_jp462/Dockerfile
@@ -44,31 +44,30 @@ RUN CUDAPKG=$(echo $CUDA | sed 's/\./-/'); \
 #################################
 
 RUN apt-get update -y \
-    && apt-get install -y python3-libnvinfer-dev zip \
+    && apt-get install -y python3-libnvinfer-dev zip wget \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
 # patching for JP4.6.2 for Jetson NX 16GB
-COPY TensorRT8.2FixforJetsonNX16GB.zip .
-RUN mkdir /jp46_patch && mv TensorRT8.2FixforJetsonNX16GB.zip /jp46_patch \
-    && cd /jp46_patch && unzip TensorRT8.2FixforJetsonNX16GB.zip 
-
-RUN dpkg -i /jp46_patch/libnvinfer8_8.2.1-1+cuda10.2_arm64.deb \
-    && dpkg -i /jp46_patch/libnvinfer-dev_8.2.1-1+cuda10.2_arm64.deb \
-    && dpkg -i /jp46_patch/libnvinfer-plugin8_8.2.1-1+cuda10.2_arm64.deb \
-    && dpkg -i /jp46_patch/libnvinfer-plugin-dev_8.2.1-1+cuda10.2_arm64.deb \
-    && dpkg -i /jp46_patch/libnvonnxparsers8_8.2.1-1+cuda10.2_arm64.deb \
-    && dpkg -i /jp46_patch/libnvonnxparsers-dev_8.2.1-1+cuda10.2_arm64.deb \
-    && dpkg -i /jp46_patch/libnvparsers8_8.2.1-1+cuda10.2_arm64.deb \
-    && dpkg -i /jp46_patch/libnvparsers-dev_8.2.1-1+cuda10.2_arm64.deb \
-    && dpkg -i /jp46_patch/libnvinfer-bin_8.2.1-1+cuda10.2_arm64.deb \
-    && dpkg -i /jp46_patch/libnvinfer-doc_8.2.1-1+cuda10.2_all.deb \
-    && dpkg -i /jp46_patch/libnvinfer-samples_8.2.1-1+cuda10.2_all.deb \
-    && dpkg -i /jp46_patch/tensorrt_8.2.1.9-1+cuda10.2_arm64.deb \
-    && dpkg -i /jp46_patch/python3-libnvinfer_8.2.1-1+cuda10.2_arm64.deb \
-    && dpkg -i /jp46_patch/python3-libnvinfer-dev_8.2.1-1+cuda10.2_arm64.deb \
-    && dpkg -i /jp46_patch/graphsurgeon-tf_8.2.1-1+cuda10.2_arm64.deb \
-    && dpkg -i /jp46_patch/uff-converter-tf_8.2.1-1+cuda10.2_arm64.deb \
+RUN mkdir /jp46_patch && cd /jp46_patch \
+    && wget https://developer.nvidia.com/tensorrt-8219-patch-jetpack46-jetson-nx-16gbtargz -O  TensorRT8.2FixforJetsonNX16GB.tar.gz  \
+    && tar zxvf TensorRT8.2FixforJetsonNX16GB.tar.gz \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/libnvinfer8_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/libnvinfer-dev_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/libnvinfer-plugin8_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/libnvinfer-plugin-dev_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/libnvonnxparsers8_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/libnvonnxparsers-dev_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/libnvparsers8_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/libnvparsers-dev_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/libnvinfer-bin_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/libnvinfer-doc_8.2.1-1+cuda10.2_all.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/libnvinfer-samples_8.2.1-1+cuda10.2_all.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/tensorrt_8.2.1.9-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/python3-libnvinfer_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/python3-libnvinfer-dev_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/graphsurgeon-tf_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/uff-converter-tf_8.2.1-1+cuda10.2_arm64.deb \
     && rm -rf /usr/local/cuda-$CUDA/targets/aarch64-linux/lib/*.a \
     && rm -rf /usr/lib/aarch64-linux-gnu/libnvinfer_static.a \
     && rm -rf /usr/lib/aarch64-linux-gnu/libnvinfer_plugin_static.a \
@@ -126,7 +125,6 @@ RUN apt-get update && \
         libomp-dev \
         python3-pip \
         python3-dev \
-        wget \
         && rm -rf /var/lib/apt/lists/* \
         && apt-get clean
 
@@ -224,7 +222,7 @@ RUN echo "patching _GLIBCXX_USE_CXX11_ABI in ${TORCH_CMAKE_CONFIG}" && \
 
 ARG PYTHON_EGG_CACHE="/panorama/.cache"
 RUN nm -D /usr/lib/aarch64-linux-gnu/libnvinfer.so | grep tensorrt_version
-RUN python3.6 -c "import torch; import torchvision;"
+RUN python3.6 -c "import torch; import torchvision; import pycuda;"
 RUN python3.6 -m pip cache purge
 
 

--- a/samples/TF37_opengpu/dependencies/docker_tf27_py36_jp462/Dockerfile
+++ b/samples/TF37_opengpu/dependencies/docker_tf27_py36_jp462/Dockerfile
@@ -8,7 +8,9 @@ RUN python3.7 -m pip uninstall -y numpy \
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg2 \
-    ca-certificates
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean 
 
 # COPY jetson-ota-public.key /etc/jetson-ota-public.key
 # RUN apt-key add /etc/jetson-ota-public.key
@@ -40,7 +42,11 @@ RUN apt-get update && \
        libhdf5-dev \
        zlib1g-dev \
        zip \
-       libjpeg8-dev
+       libjpeg8-dev \
+       wget \
+       unzip \
+       && rm -rf /var/lib/apt/lists/* \
+       && apt-get clean
 
 #RUN mkdir -p /usr/lib/python3.7/lib-dynload
 #RUN cp /usr/lib/python3.7/lib-dynload/panoramasdk.so /usr/lib/python3.7/lib-dynload/panoramasdk.so
@@ -59,13 +65,37 @@ RUN CUDAPKG=$(echo $CUDA | sed 's/\./-/'); \
     libcudnn8 \
     tensorrt \
     && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
+    && apt-get clean \
+    && rm -rf /usr/local/cuda-$CUDA/targets/aarch64-linux/lib/*.a \
+    && rm -rf /usr/lib/aarch64-linux-gnu/libnvinfer_static.a \
+    && rm -rf /usr/lib/aarch64-linux-gnu/libnvinfer_plugin_static.a \
+    && rm -rf /usr/lib/aarch64-linux-gnu/*static*
 
-#Remove static libraries to save space
-RUN rm -rf /usr/local/cuda-$CUDA/targets/aarch64-linux/lib/*.a
-RUN rm -rf /usr/local/cuda-$CUDA/lib64/*.a
-RUN rm -rf /usr/lib/aarch64-linux-gnu/libnvinfer_static.a
-RUN rm -rf /usr/lib/aarch64-linux-gnu/libnvinfer_plugin_static.a
+COPY TensorRT8.2FixforJetsonNX16GB.zip .
+RUN mkdir /jp46_patch && mv TensorRT8.2FixforJetsonNX16GB.zip /jp46_patch \
+    && cd /jp46_patch && unzip TensorRT8.2FixforJetsonNX16GB.zip 
+
+RUN dpkg -i /jp46_patch/libnvinfer8_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/libnvinfer-dev_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/libnvinfer-plugin8_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/libnvinfer-plugin-dev_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/libnvonnxparsers8_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/libnvonnxparsers-dev_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/libnvparsers8_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/libnvparsers-dev_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/libnvinfer-bin_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/libnvinfer-doc_8.2.1-1+cuda10.2_all.deb \
+    && dpkg -i /jp46_patch/libnvinfer-samples_8.2.1-1+cuda10.2_all.deb \
+    && dpkg -i /jp46_patch/tensorrt_8.2.1.9-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/python3-libnvinfer_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/python3-libnvinfer-dev_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/graphsurgeon-tf_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/uff-converter-tf_8.2.1-1+cuda10.2_arm64.deb \
+    && rm -rf /usr/local/cuda-$CUDA/targets/aarch64-linux/lib/*.a \
+    && rm -rf /usr/lib/aarch64-linux-gnu/libnvinfer_static.a \
+    && rm -rf /usr/lib/aarch64-linux-gnu/libnvinfer_plugin_static.a \
+    && rm -rf /usr/lib/aarch64-linux-gnu/*static* \
+    && rm -r /jp46_patch
 
 ENV LIBRARY_PATH /usr/local/cuda/lib64/stubs
 
@@ -100,8 +130,6 @@ ENV LD_LIBRARY_PATH /usr/local/cuda-$CUDA/targets/aarch64-linux/lib:${LD_LIBRARY
 
 ENV DEBIAN_FRONTEND=noninteractive
 ARG HDF5_DIR="/usr/lib/aarch64-linux-gnu/hdf5/serial/"
-ARG MAKEFLAGS=-j$(nproc)
-
 RUN printenv
 
 #
@@ -115,9 +143,6 @@ RUN env H5PY_SETUP_REQUIRES=0 python3.6 -m pip install -U --no-cache-dir --verbo
 #
 # TensorFlow 2.4. See build instructions for building tensorflow wheel here: https://apivovarov.medium.com/run-tensorflow-2-object-detection-models-with-tensorrt-on-jetson-xavier-using-tf-c-api-e34548818ac6
 #
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends wget
-
 ARG TENSORFLOW_WHL=tensorflow-2.7.0+nv22.1-cp36-cp36m-linux_aarch64.whl
 RUN wget "https://developer.download.nvidia.com/compute/redist/jp/v461/tensorflow/${TENSORFLOW_WHL}" -O ${TENSORFLOW_WHL} \
     && python3.6 -m pip install --pre --verbose ${TENSORFLOW_WHL} \
@@ -125,6 +150,7 @@ RUN wget "https://developer.download.nvidia.com/compute/redist/jp/v461/tensorflo
 
 
 RUN python3 -c "import tensorflow as tf; print(tf.__version__)"
+RUN nm -D /usr/lib/aarch64-linux-gnu/libnvinfer.so | grep tensorrt_version
 
 
 #

--- a/samples/TF37_opengpu/dependencies/docker_tf27_py36_jp462/Dockerfile
+++ b/samples/TF37_opengpu/dependencies/docker_tf27_py36_jp462/Dockerfile
@@ -71,26 +71,27 @@ RUN CUDAPKG=$(echo $CUDA | sed 's/\./-/'); \
     && rm -rf /usr/lib/aarch64-linux-gnu/libnvinfer_plugin_static.a \
     && rm -rf /usr/lib/aarch64-linux-gnu/*static*
 
-COPY TensorRT8.2FixforJetsonNX16GB.zip .
-RUN mkdir /jp46_patch && mv TensorRT8.2FixforJetsonNX16GB.zip /jp46_patch \
-    && cd /jp46_patch && unzip TensorRT8.2FixforJetsonNX16GB.zip 
 
-RUN dpkg -i /jp46_patch/libnvinfer8_8.2.1-1+cuda10.2_arm64.deb \
-    && dpkg -i /jp46_patch/libnvinfer-dev_8.2.1-1+cuda10.2_arm64.deb \
-    && dpkg -i /jp46_patch/libnvinfer-plugin8_8.2.1-1+cuda10.2_arm64.deb \
-    && dpkg -i /jp46_patch/libnvinfer-plugin-dev_8.2.1-1+cuda10.2_arm64.deb \
-    && dpkg -i /jp46_patch/libnvonnxparsers8_8.2.1-1+cuda10.2_arm64.deb \
-    && dpkg -i /jp46_patch/libnvonnxparsers-dev_8.2.1-1+cuda10.2_arm64.deb \
-    && dpkg -i /jp46_patch/libnvparsers8_8.2.1-1+cuda10.2_arm64.deb \
-    && dpkg -i /jp46_patch/libnvparsers-dev_8.2.1-1+cuda10.2_arm64.deb \
-    && dpkg -i /jp46_patch/libnvinfer-bin_8.2.1-1+cuda10.2_arm64.deb \
-    && dpkg -i /jp46_patch/libnvinfer-doc_8.2.1-1+cuda10.2_all.deb \
-    && dpkg -i /jp46_patch/libnvinfer-samples_8.2.1-1+cuda10.2_all.deb \
-    && dpkg -i /jp46_patch/tensorrt_8.2.1.9-1+cuda10.2_arm64.deb \
-    && dpkg -i /jp46_patch/python3-libnvinfer_8.2.1-1+cuda10.2_arm64.deb \
-    && dpkg -i /jp46_patch/python3-libnvinfer-dev_8.2.1-1+cuda10.2_arm64.deb \
-    && dpkg -i /jp46_patch/graphsurgeon-tf_8.2.1-1+cuda10.2_arm64.deb \
-    && dpkg -i /jp46_patch/uff-converter-tf_8.2.1-1+cuda10.2_arm64.deb \
+# patching for JP4.6.2 for Jetson NX 16GB
+RUN mkdir /jp46_patch && cd /jp46_patch \
+    && wget https://developer.nvidia.com/tensorrt-8219-patch-jetpack46-jetson-nx-16gbtargz -O  TensorRT8.2FixforJetsonNX16GB.tar.gz  \
+    && tar zxvf TensorRT8.2FixforJetsonNX16GB.tar.gz \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/libnvinfer8_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/libnvinfer-dev_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/libnvinfer-plugin8_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/libnvinfer-plugin-dev_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/libnvonnxparsers8_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/libnvonnxparsers-dev_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/libnvparsers8_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/libnvparsers-dev_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/libnvinfer-bin_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/libnvinfer-doc_8.2.1-1+cuda10.2_all.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/libnvinfer-samples_8.2.1-1+cuda10.2_all.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/tensorrt_8.2.1.9-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/python3-libnvinfer_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/python3-libnvinfer-dev_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/graphsurgeon-tf_8.2.1-1+cuda10.2_arm64.deb \
+    && dpkg -i /jp46_patch/TensorRT_8.2.1.9_Patch_for_Jetpack4.6_Jetson_NX_16GB/uff-converter-tf_8.2.1-1+cuda10.2_arm64.deb \
     && rm -rf /usr/local/cuda-$CUDA/targets/aarch64-linux/lib/*.a \
     && rm -rf /usr/lib/aarch64-linux-gnu/libnvinfer_static.a \
     && rm -rf /usr/lib/aarch64-linux-gnu/libnvinfer_plugin_static.a \


### PR DESCRIPTION
*Issue #, if available:*

- This is a patch from Nvidia for fixing the TensorRT error in Jetson NX 16G device. 
- https://developer.nvidia.com/embedded/linux-tegra-r3272 (at the bottom of the page)

*Description of changes:*

- Adding this patch in Dockerfile of ONNX2TRT app and TF27 app to upgrade TensorRT to 8.2.1.9.
- Reduce the docker image size.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
