### PR TITLE
Update sideloading_cli.py

### DIFF
--- a/tools/sideloading/sideloading_cli.py
+++ b/tools/sideloading/sideloading_cli.py
@@ -13,7 +13,7 @@ import argparse
 python_version_tuple = ( sys.version_info.major, sys.version_info.minor, sys.version_info.micro )
 min_python_version_tuple = (3,7,0)
 if python_version_tuple < min_python_version_tuple:
-    print( "Warning : Python versions older than {min_python_version_tuple[0]}.{min_python_version_tuple[1]} is not supported." )
+    print( f"Warning : Python versions older than {min_python_version_tuple[0]}.{min_python_version_tuple[1]} is not supported." )
 
 
 ignore_patterns = [


### PR DESCRIPTION
Fix minimum supported version warning.

*Issue #, if available:*
Before adding the fix
```
Warning : Python versions older than {min_python_version_tuple[0]}.{min_python_version_tuple[1]} is not supported.
```

*Description of changes:*
After fix
```
Warning : Python versions older than 3.7 is not supported.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
