### PR TITLE
Remove memory leak caused by ByteTrack

### DIFF
--- a/samples/mot_analysis/mot_analysis_app/packages/123456789012-MOT_ANALYSIS_CODE-1.0/src/bytetracker/byte_tracker.py
+++ b/samples/mot_analysis/mot_analysis_app/packages/123456789012-MOT_ANALYSIS_CODE-1.0/src/bytetracker/byte_tracker.py
@@ -283,6 +283,8 @@ class BYTETracker(object):
         self.lost_stracks.extend(lost_stracks)
         self.lost_stracks = sub_stracks(self.lost_stracks, self.removed_stracks)
         self.removed_stracks.extend(removed_stracks)
+        if len(self.removed_stracks) > 100:
+            self.removed_stracks = self.removed_stracks[-99:]
         self.tracked_stracks, self.lost_stracks = remove_duplicate_stracks(self.tracked_stracks, self.lost_stracks)
         # get scores of lost tracks
         output_stracks = [track for track in self.tracked_stracks if track.is_activated]


### PR DESCRIPTION
*Issue #, if available:*

There is a memory leak in the official ByteTrack script caused by the `self.removed_stracks` variable which is allowed to grow indefinitely. This issue (&fix) was raised in the ByteTrack repo as well but the devs dont seem to be active anymore and arent reviewing pull requests. 

*Description of changes:*

The Ultralytics yolov8 repo also had this same bug and together with their devs, we fixed it by adding these two lines which simply keep a fixed length of 100 to the history of removed tracks. This effectively fixes the memory leak without any impact on the accuracy of the tracker. See [here](https://github.com/ultralytics/ultralytics/pull/1890)  for more info.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
