### PR TITLE
Added 3 regions in the region-AMI mapping and removed default keypair name

### DIFF
--- a/samples/common/test_utility/cf_template/ec2-instance-panorama.yml
+++ b/samples/common/test_utility/cf_template/ec2-instance-panorama.yml
@@ -5,7 +5,6 @@ Parameters:
     Description: Name of an existing EC2 KeyPair to enable SSH access to the instance
     Type: AWS::EC2::KeyPair::KeyName
     ConstraintDescription: must be the name of an existing EC2 KeyPair.
-    Default: Surya_Arm64_key
   InstanceType:
     Description: WebServer EC2 instance type
     Type: String
@@ -36,6 +35,13 @@ Mappings:
       id: ami-01747bf371bd30817
     ap-northeast-1:
       id: ami-01747bf371bd30817
+    ap-southeast-1:
+      id: ami-0981694bf98b9afc3
+    ap-southeast-2:
+      id: ami-0e8a397bcbe9f9bfe
+    ca-central-1:
+      id: ami-02406f712ec60968d
+
 Resources:
   ec2Instance:
     Type: AWS::EC2::Instance


### PR DESCRIPTION
*Description of changes:*

Added 3 regions in the region-AMI mapping 
- ap-southeast-1, ap-southeast-2, ca-central-1

Removed default keypaid name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
