### PR TITLE
modify --model-s3-uri to include /{model_node_name}/

### DIFF
--- a/samples/car_tracker/car_tracker_tutorial.ipynb
+++ b/samples/car_tracker/car_tracker_tutorial.ipynb
@@ -252,7 +252,7 @@
    "source": [
     "!cd ./car_tracker_app && panorama-cli add-raw-model \\\n",
     "    --model-asset-name {model_asset_name} \\\n",
-    "    --model-s3-uri s3://{S3_BUCKET}/{app_name}/{ML_MODEL_FNAME}.tar.gz \\\n",
+    "    --model-s3-uri s3://{S3_BUCKET}/{app_name}/{model_node_name}/{ML_MODEL_FNAME}.tar.gz \\\n",
     "    --descriptor-path {model_descriptor_path}  \\\n",
     "    --packages-path {model_package_path}"
    ]


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/aws-panorama-samples/issues/87

*Description of changes:*
In the [car_tracker_tutorial.ipynb](https://github.com/aws-samples/aws-panorama-samples/blob/main/samples/car_tracker/car_tracker_tutorial.ipynb) sample notebook, the below cell is failed with S3 404 error.

```
!cd ./car_tracker_app && panorama-cli add-raw-model \
    --model-asset-name {model_asset_name} \
    --model-s3-uri s3://{S3_BUCKET}/{app_name}/{ML_MODEL_FNAME}.tar.gz \
    --descriptor-path {model_descriptor_path}  \
    --packages-path {model_package_path}
```

The cause is `--model-s3-uri` is the wrong path, which does not contain `{model_node_name}`.
- Fail : --model-s3-uri s3://{S3_BUCKET}/{app_name}/{ML_MODEL_FNAME}.tar.gz
- Success : --model-s3-uri s3://{S3_BUCKET}/{app_name}/{model_node_name}/{ML_MODEL_FNAME}.tar.gz

SageMaker Compilation job's output is specified as `s3://{S3_BUCKET}/{app_name}/{model_node_name}/`, so the path should contain `/{model_node_name}/` prefix.

I modified its `--model-s3-uri ` to include  `/{model_node_name}/` prefix.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
