### PR TITLE
ONNX2TRT: Fix illegal instruction error caused by numpy 1.19.5.

### DIFF
--- a/samples/ONNX2TRT_opengpu/dependencies/docker_jp462/Dockerfile
+++ b/samples/ONNX2TRT_opengpu/dependencies/docker_jp462/Dockerfile
@@ -137,15 +137,15 @@ RUN wget https://panorama-starter-kit.s3.amazonaws.com/public/v2/opengpusamples/
 ##################
 # Install Pycuda #
 ##################
+# upgrade pip for opencv, numpy and other libs
+RUN python3.6 -m pip  install --upgrade pip
 RUN python3.6 -m pip install --no-cache-dir setuptools Cython wheel
-RUN python3.6 -m pip install --no-cache-dir numpy
+RUN python3.6 -m pip install --no-cache-dir numpy==1.19.4
 
 ENV PATH="/usr/local/cuda/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/usr/local/cuda/lib64:${LD_LIBRARY_PATH}"
 RUN echo "$PATH" && echo "$LD_LIBRARY_PATH"
 
-# upgrade pip for opencv and other libs
-RUN python3.6 -m pip  install --upgrade pip
 RUN python3.6 -m pip install --no-cache-dir pycuda==2020.1 six
 
 #
@@ -163,7 +163,7 @@ RUN python3.6 -m pip install --no-cache-dir pycuda==2020.1 six
 #     && rm -rf /var/lib/apt/lists/* \
 #     && apt-get clean
 
-RUN python3.6 -m pip install --no-cache-dir opencv-python
+RUN python3.6 -m pip install --no-cache-dir opencv-python==4.6.0.66
 
 
 ######################


### PR DESCRIPTION
*Issue #, if available:*

- The issue comes from the numpy 1.19.5 will cause Illegal Instruction error on Jetson device.
https://github.com/numpy/numpy/issues/18131 

*Description of changes:*

- This hotfix is done by downgrading the numpy version to 1.19.4 for python3.6.
- The changes has been tested on AWS Panorama and works well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
