### PR TITLE
fix: cython new version cause h5py install error.

### DIFF
--- a/samples/TF37_opengpu/dependencies/docker/Dockerfile
+++ b/samples/TF37_opengpu/dependencies/docker/Dockerfile
@@ -2,7 +2,9 @@ FROM public.ecr.aws/panorama/panorama-application:latest
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg2 \
-    ca-certificates
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean 
 
 # COPY jetson-ota-public.key /etc/jetson-ota-public.key
 # RUN apt-key add /etc/jetson-ota-public.key
@@ -13,27 +15,6 @@ ARG RELEASE=r32.4
 RUN echo "deb https://repo.download.nvidia.com/jetson/common $RELEASE main" >> /etc/apt/sources.list
 RUN echo "deb https://repo.download.nvidia.com/jetson/t194 $RELEASE main" >> /etc/apt/sources.list
 RUN apt-key adv --fetch-key http://repo.download.nvidia.com/jetson/jetson-ota-public.asc
-
-
-#
-# install prerequisites - https://docs.nvidia.com/deeplearning/frameworks/install-tf-jetson-platform/index.html#prereqs
-#
-RUN apt-get update && \
- apt-get install -y --no-install-recommends \
-       python3-dev \
-       python3.7-dev \
-       libpython3.7-dev \
-       python3-pip \
-       gfortran \
-       build-essential \
-       liblapack-dev \
-       libblas-dev \
-       libhdf5-serial-dev \
-       hdf5-tools \
-       libhdf5-dev \
-       zlib1g-dev \
-       zip \
-       libjpeg8-dev
 
 #RUN mkdir -p /usr/lib/python3.7/lib-dynload
 #RUN cp /usr/lib/python3.7/lib-dynload/panoramasdk.so /usr/lib/python3.7/lib-dynload/panoramasdk.so
@@ -47,18 +28,14 @@ RUN CUDAPKG=$(echo $CUDA | sed 's/\./-/'); \
 	cuda-nvtx-$CUDAPKG \
 	cuda-libraries-dev-$CUDAPKG \
 	cuda-minimal-build-$CUDAPKG \
-	cuda-license-$CUDAPKG \
-	cuda-command-line-tools-$CUDAPKG \
     libcudnn8 \
     tensorrt \
     && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
-
-#Remove static libraries to save space
-RUN rm -rf /usr/local/cuda-$CUDA/targets/aarch64-linux/lib/*.a
-RUN rm -rf /usr/local/cuda-$CUDA/lib64/*.a
-RUN rm -rf /usr/lib/aarch64-linux-gnu/libnvinfer_static.a
-RUN rm -rf /usr/lib/aarch64-linux-gnu/libnvinfer_plugin_static.a
+    && apt-get clean \
+    && rm -rf /usr/local/cuda-$CUDA/targets/aarch64-linux/lib/*.a \
+    && rm -rf /usr/lib/aarch64-linux-gnu/libnvinfer_static.a \
+    && rm -rf /usr/lib/aarch64-linux-gnu/libnvinfer_plugin_static.a \
+    && rm -rf /usr/lib/aarch64-linux-gnu/*static*
 
 ENV LIBRARY_PATH /usr/local/cuda/lib64/stubs
 
@@ -93,50 +70,61 @@ ENV LD_LIBRARY_PATH /usr/local/cuda-$CUDA/targets/aarch64-linux/lib:${LD_LIBRARY
 
 ENV DEBIAN_FRONTEND=noninteractive
 ARG HDF5_DIR="/usr/lib/aarch64-linux-gnu/hdf5/serial/"
-ARG MAKEFLAGS=-j$(nproc)
 
-RUN printenv
+
+#
+# install prerequisites - https://docs.nvidia.com/deeplearning/frameworks/install-tf-jetson-platform/index.html#prereqs
+#
+RUN apt-get update && \
+ apt-get install -y --no-install-recommends \
+       python3-dev \
+       python3.7-dev \
+       libpython3.7-dev \
+       python3-pip \
+       gfortran \
+       liblapack-dev \
+       libblas-dev \
+       libhdf5-serial-dev \
+       hdf5-tools \
+       libhdf5-dev \
+       zlib1g-dev \
+       zip \
+       libjpeg8-dev \
+       wget \
+       && rm -rf /var/lib/apt/lists/* \
+       && apt-get clean
+
+# build-essential \
 
 #
 # Install tensorflow dependencies
 #
-RUN python3.7 -m pip install --no-cache-dir setuptools Cython wheel
+RUN python3.7 -m pip install --no-cache-dir setuptools Cython==0.29.32 wheel
 RUN python3.7 -m pip install --no-cache-dir --verbose numpy
-RUN python3.7 -m pip install --no-cache-dir --verbose h5py==2.10.0
 RUN python3.7 -m pip install --no-cache-dir --verbose future==0.18.2 mock==3.0.5 h5py==2.10.0 keras_preprocessing==1.1.1 keras_applications==1.0.8 gast==0.2.2 futures protobuf pybind11
 
 #
 # TensorFlow 2.4. See build instructions for building tensorflow wheel here: https://apivovarov.medium.com/run-tensorflow-2-object-detection-models-with-tensorrt-on-jetson-xavier-using-tf-c-api-e34548818ac6
 #
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends wget
-
-RUN wget https://panorama-starter-kit.s3.amazonaws.com/public/v2/opengpusamples/TF_Sample/Docker/tensorflow-2.4.4-cp37-cp37m-linux_aarch64.whl .
 ARG TENSORFLOW_WHL=tensorflow-2.4.4-cp37-cp37m-linux_aarch64.whl
-
-RUN python3.7 -m pip install --pre --verbose ${TENSORFLOW_WHL} && \
-    rm ${TENSORFLOW_WHL}
+RUN wget https://panorama-starter-kit.s3.amazonaws.com/public/v2/opengpusamples/TF_Sample/Docker/tensorflow-2.4.4-cp37-cp37m-linux_aarch64.whl \
+    && python3.7 -m pip install --pre --verbose ${TENSORFLOW_WHL} \
+    && rm ${TENSORFLOW_WHL}
+    
 
 #
 # PyCUDA
 #
-ENV PATH="/usr/local/cuda/bin:${PATH}"
-ENV LD_LIBRARY_PATH="/usr/local/cuda/lib64:${LD_LIBRARY_PATH}"
-RUN echo "$PATH" && echo "$LD_LIBRARY_PATH"
+# ENV PATH="/usr/local/cuda/bin:${PATH}"
+# ENV LD_LIBRARY_PATH="/usr/local/cuda/lib64:${LD_LIBRARY_PATH}"
+# RUN echo "$PATH" && echo "$LD_LIBRARY_PATH"
 
-RUN python3.7 -m pip install --no-cache-dir --verbose pycuda six
-RUN pip3 install --upgrade numpy
-#
-# Run ld config
-#
-RUN ldconfig
+# RUN python3.7 -m pip install --no-cache-dir --verbose pycuda six
 
-#
-# Set environment variables
-# Note: These environment variables don't get persisted for runtime.
-#
-ENV NVIDIA_VISIBLE_DEVICES all
-ENV NVIDIA_DRIVER_CAPABILITIES all
+# Fix "Check failed: PyBfloat16_Type.tp_base != nullptr"
+RUN python3.7 -m pip install --upgrade --no-cache-dir numpy
+
+RUN python3.7 -c "import tensorflow; import numpy; from tensorflow.python.compiler.tensorrt import trt_convert as trt"
 
 CMD [ "/bin/bash" ]

--- a/samples/TF37_opengpu/dependencies/docker_tf27_py36_jp462/Dockerfile
+++ b/samples/TF37_opengpu/dependencies/docker_tf27_py36_jp462/Dockerfile
@@ -138,11 +138,11 @@ RUN printenv
 # Following the tutorial here https://docs.nvidia.com/deeplearning/frameworks/install-tf-jetson-platform/index.html#prereqs
 RUN python3 --version
 RUN python3.6 -m pip install -U --no-cache-dir pip testresources setuptools==49.6.0 
-RUN python3.6 -m pip install --no-cache-dir Cython wheel
-RUN python3.6 -m pip install --no-cache-dir -U --no-deps numpy==1.19.4 future==0.18.2 mock==3.0.5 keras_preprocessing==1.1.2 keras_applications==1.0.8 gast==0.4.0 protobuf pybind11 cython pkgconfig packaging
+RUN python3.6 -m pip install --no-cache-dir Cython==0.29.32 wheel
+RUN python3.6 -m pip install --no-cache-dir -U --no-deps numpy==1.19.4 future==0.18.2 mock==3.0.5 keras_preprocessing==1.1.2 keras_applications==1.0.8 gast==0.4.0 protobuf pybind11 pkgconfig packaging
 RUN env H5PY_SETUP_REQUIRES=0 python3.6 -m pip install -U --no-cache-dir --verbose h5py==3.1.0
 #
-# TensorFlow 2.4. See build instructions for building tensorflow wheel here: https://apivovarov.medium.com/run-tensorflow-2-object-detection-models-with-tensorrt-on-jetson-xavier-using-tf-c-api-e34548818ac6
+# TensorFlow 2.7. See build instructions for building tensorflow wheel here: https://apivovarov.medium.com/run-tensorflow-2-object-detection-models-with-tensorrt-on-jetson-xavier-using-tf-c-api-e34548818ac6
 #
 ARG TENSORFLOW_WHL=tensorflow-2.7.0+nv22.1-cp36-cp36m-linux_aarch64.whl
 RUN wget "https://developer.download.nvidia.com/compute/redist/jp/v461/tensorflow/${TENSORFLOW_WHL}" -O ${TENSORFLOW_WHL} \
@@ -159,14 +159,6 @@ RUN nm -D /usr/lib/aarch64-linux-gnu/libnvinfer.so | grep tensorrt_version
 #
 ENV PATH="/usr/local/cuda/bin:${PATH}"
 ENV LD_LIBRARY_PATH="/usr/local/cuda/lib64:${LD_LIBRARY_PATH}"
-# RUN echo "$PATH" && echo "$LD_LIBRARY_PATH"
-
-# RUN python3.7 -m pip install --no-cache-dir --verbose pycuda six
-# RUN pip3 install --upgrade numpy
-#
-# Run ld config
-#
-# RUN ldconfig
 
 #
 # Set environment variables

--- a/samples/TF37_opengpu/tf2_4_trt_app/packages/028663699634-tf2_4_trt_app-1.0/package.json
+++ b/samples/TF37_opengpu/tf2_4_trt_app/packages/028663699634-tf2_4_trt_app-1.0/package.json
@@ -5,6 +5,29 @@
         "version": "1.0",
         "description": "Default description for package tf2_4_trt_app",
         "assets": [
+            {
+                "name": "tf24_trt_app",
+                "implementations": [
+                    {
+                        "type": "container",
+                        "assetUri": "24c9132d93e0990663eaf1f00a93ef1da2ff8938e51a585a4cbf5cac0c942d17.tar.gz",
+                        "descriptorUri": "bdabbfe61350567c6e83c0298d8900d96a8eb38b7a99adc99bb13c4256a9b937.json",
+                        "requirements": [
+                            {
+                                "type": "hardware_access",
+                                "inferenceAccelerators": [
+                                    {
+                                        "deviceType": "nvhost_gpu",
+                                        "sharedResourcePolicy": {
+                                            "policy": "allow_all"
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
         ],
         "interfaces": [
             {

--- a/samples/TF37_opengpu/tf2_7_trt_app/packages/937544830708-tf2_7_trt_app-1.0/Dockerfile
+++ b/samples/TF37_opengpu/tf2_7_trt_app/packages/937544830708-tf2_7_trt_app-1.0/Dockerfile
@@ -1,6 +1,6 @@
 # Use the pre-built docker image attached in this example by doing ```docker load --input panoramasdk_gpu_access_base_image.tar.gz``` or build the base image yourself using the dockerfile provided under /docker/Dockerfile
 FROM tf27:latest
 RUN apt-get update && apt-get install -y libglib2.0-0
-RUN python3.6 -m pip install opencv-python boto3
+RUN python3.6 -m pip install opencv-python==4.6.0.66 boto3
 COPY saved_model_trt_fp16 /panorama/saved_model_trt_fp16_tf27
 COPY src /panorama


### PR DESCRIPTION
*Issue #, if available:*
Recently the pip will install cython 3.0+  instead of 0.29.x (https://pypi.org/project/Cython/#history). However, building the h5py with cython 3.0+ causes errors. Thus in this PR we are trying to fix this issue.

*Description of changes:*
- The main change is fix the cython version with 0.29.32 and opencv version 4.6.0.66
- The dockerfile for TF24 (JP44, samples/TF37_opengpu/dependencies/docker/Dockerfile) is aligned with the main branch and also updated the cython version to 0.29.32.
- Adding the OpenGPU requirements to TF24 package.json.

Have tested both TF24 and TF27 on the Panorama device.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
