### PR TITLE
feat: update the cf stack to spin up EC2 with Ubuntu 20.04

### DIFF
--- a/samples/common/test_utility/cf_template/ec2-instance-panorama.yml
+++ b/samples/common/test_utility/cf_template/ec2-instance-panorama.yml
@@ -22,25 +22,25 @@ Parameters:
     AllowedPattern: (\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})
     ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x.
 Mappings: 
-  RegionMap: 
+  RegionMap: # Ubuntu Server 20.04 LTS (HVM), SSD Volume Type
     us-east-1:
-      id: ami-01747bf371bd30817
+      id: ami-0a75bd84854bc95c9
     us-east-2:
-      id: ami-01747bf371bd30817
+      id: ami-06b74af9fe7907906
     us-west-2:
-      id: ami-0a8e148ec03558c68
+      id: ami-05f290e7e87696c29
     eu-central-1:
-      id: ami-01747bf371bd30817
+      id: ami-0662ac347458e7d4c
     eu-west-1:
-      id: ami-01747bf371bd30817
+      id: ami-07a436be3d0883136
     ap-northeast-1:
-      id: ami-01747bf371bd30817
+      id: ami-0204c9bcdc2f0250d
     ap-southeast-1:
-      id: ami-0981694bf98b9afc3
+      id: ami-02cbb518252acafee
     ap-southeast-2:
-      id: ami-0e8a397bcbe9f9bfe
+      id: ami-051dba585c12c8e8b
     ca-central-1:
-      id: ami-02406f712ec60968d
+      id: ami-00b9da4a345757cb4
 
 Resources:
   ec2Instance:
@@ -66,42 +66,81 @@ Resources:
                 echo $HOME > $HOME/user_data.txt
 
                 apt -y update && apt -y upgrade
-                apt-get -y install wget build-essential checkinstall
-                apt-get install -y libreadline-gplv2-dev libncursesw5-dev libssl-dev \
-                    libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev libffi-dev zlib1g-dev
-                apt-get install python3-dev python3-pip python3-numpy -y
-                apt-get install -y build-essential cmake git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev  libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libdc1394-22-dev protobuf-compiler libgflags-dev libgoogle-glog-dev libblas-dev libhdf5-serial-dev liblmdb-dev libleveldb-dev liblapack-dev libsnappy-dev libprotobuf-dev libopenblas-dev libgtk2.0-dev libboost-dev libboost-all-dev libeigen3-dev libatlas-base-dev libne10-10 libne10-dev
-                
+                apt -y install \
+                    wget \
+                    build-essential \
+                    checkinstall \
+                    libreadline-gplv2-dev \
+                    libncursesw5-dev \
+                    libssl-dev \
+                    libsqlite3-dev \
+                    tk-dev \
+                    libgdbm-dev \
+                    libc6-dev \
+                    libbz2-dev \
+                    libffi-dev \
+                    zlib1g-dev \
+                    python3 \
+                    python3-dev \
+                    python3-pip \
+                    python3-numpy \
+                    python3-distutils \
+                    python3-testresources \
+                    cmake \
+                    git \
+                    libgtk2.0-dev \
+                    pkg-config \
+                    libavcodec-dev \
+                    libavformat-dev \
+                    libswscale-dev \
+                    libtbb2 \
+                    libtbb-dev \
+                    libjpeg-dev \
+                    libpng-dev \
+                    libtiff-dev \
+                    libdc1394-22-dev \
+                    protobuf-compiler \
+                    libgflags-dev \
+                    libgoogle-glog-dev \
+                    libblas-dev \
+                    libhdf5-serial-dev \
+                    liblmdb-dev \
+                    libleveldb-dev \
+                    liblapack-dev \
+                    libsnappy-dev \
+                    libprotobuf-dev \
+                    libopenblas-dev \
+                    libboost-dev \
+                    libboost-all-dev \
+                    libeigen3-dev \
+                    libatlas-base-dev \
+                    libne10-10 \
+                    libne10-dev \
+                    curl \
+                    ca-certificates
+
                 echo 'installing jupyterlab'
 
-                #!/bin/bash
-
-                cd 
-                apt-get update
-                apt-get install -y python3 python3-distutils build-essential cmake curl ca-certificates
-                sudo pip3 install -U pip setuptools wheel
-
+                pip3 install -U pip setuptools wheel
                 pip3 install panoramacli
-                pip3 install jupyterlab
+                pip3 install jupyterlab==4.0.9
                 pip3 install boto3
-                sudo pip3 install matplotlib
-                pip3 install 'attrs==19.1.0' --force-reinstall
-                pip3 install sagemaker
+                pip3 install matplotlib
+                pip3 install 'attrs==23.1.0' --force-reinstall
+                # https://stackoverflow.com/questions/49911550/how-to-upgrade-disutils-package-pyyaml
+                pip3 install 'PyYAML==6.0.1' --ignore-installed 
+                pip3 install 'sagemaker==2.200.1'
                 pip3 install awscli
                 pip3 install numpy
-
-                jupyter notebook --generate-config
-
-                #!/bin/bash
+                pip3 install opencv-python boto3
 
                 pip3 install neon
-                apt-get -y install libneon27-dev
-                apt-get -y install libneon27-gnutls-dev
-                cd ~/
-                pwd
-                apt install -y unzip
-                
-                
+                # need to split libneon27-dev and libneon27-gnutls-dev into two lines for some dependency issue.
+                apt -y install libneon27-dev 
+                apt -y install libneon27-gnutls-dev unzip
+
+                jupyter lab --generate-config
+
                 echo 'cloning sample repository and download video files'
                 cd
                 sudo su - ubuntu -c "git clone https://github.com/aws-samples/aws-panorama-samples.git"                
@@ -110,54 +149,26 @@ Resources:
                 mv videos/* ./aws-panorama-samples/samples/common/test_utility/videos/
                 rmdir videos
                 rm sample-videos.zip
-
                 
                 mkdir /opt/aws
                 mkdir /opt/aws/panorama
                 mkdir /opt/aws/panorama/logs
                 mkdir /opt/aws/panorama/storage
-
-
+                
                 echo 'installing neo'
+                pip3 install dlr==1.10.0
                 
-                cd
-                sudo apt-get update
-                sudo apt-get install -y python3 python3-distutils build-essential cmake curl ca-certificates
-                sudo pip3 install -U pip setuptools wheel
-                
-                cd
-                wget https://panorama-starter-kit.s3.amazonaws.com/public/v2/Models/install-neo.sh
-                #aws s3 cp s3://panorama-starter-kit/public/v2/Models/install-neo.sh .
-                sh ./install-neo.sh
-
-
-                #echo 'Installing MXNet'
-                # wget https://panorama-starter-kit.s3.amazonaws.com/public/v2/Models/install-mxnet.sh
-                # # aws s3 cp s3://panorama-starter-kit/public/v2/Models/install-mxnet.sh .
-                # sh ./install-mxnet.sh
-                # pip3 install --upgrade gluoncv
-                # pip3 install --upgrade ipywidgets
-
-                
-                echo 'installing opencv'
-
-                cd
-                pip3 install opencv-python boto3
-
                 echo 'Install Docker'
-
-                apt-get update -y
-
-                apt-get install \
-                apt-transport-https \
-                ca-certificates \
-                curl \
-                gnupg \
-                lsb-release -y 
-
-                apt  install docker.io -y
+                apt install \
+                    apt-transport-https \
+                    gnupg \
+                    lsb-release \
+                    docker.io -y
+                
+                usermod -aG docker ubuntu
+                sudo -u ubuntu bash -c 'newgrp docker'
+                
                 aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 500245141608.dkr.ecr.us-west-2.amazonaws.com
-
                 echo "INSTALLATION COMPLETE" > $HOME/INSTALLATION_COMPLETE.txt
                 
   ec2SecurityGroup:


### PR DESCRIPTION
*Issue #, if available:*

#97 

*Description of changes:*

The Ubuntu 18.04 Bionci Arm AMI is no longer support. Thus we have changed the AMI to Ubuntu 20.04. The user data need to be updated in order to fit in Ubuntu 20.04. 

*Testing*

Have tested the cf stack and built two apps, PT37 and people counting (Neo), and deployed the apps on the device without issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
