### PR TITLE
fix: update kvs sample app Dockerfile for py3.8 compatible.

### DIFF
--- a/samples/kinesis_video_streams/.gitignore
+++ b/samples/kinesis_video_streams/.gitignore
@@ -1,0 +1,1 @@
+kinesis_video_streams_app/packages/*-kinesis_video_streams_code-1.0/src/certs/*

--- a/samples/kinesis_video_streams/README.md
+++ b/samples/kinesis_video_streams/README.md
@@ -55,6 +55,7 @@ After deploying Panorama application via execute all steps in notebook, users ca
 
 ![kvs-check](./doc/kvs_check.png)
 
+> Note that by default the app.py will resize the video resolution to 720p.
 
 ## Tips
 

--- a/samples/kinesis_video_streams/kinesis_video_streams_app/packages/201125699002-kinesis_video_streams_code-1.0/Dockerfile
+++ b/samples/kinesis_video_streams/kinesis_video_streams_app/packages/201125699002-kinesis_video_streams_code-1.0/Dockerfile
@@ -8,12 +8,10 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
 RUN update-alternatives --set python3 /usr/bin/python3.8
 
 RUN apt-get update -y && apt-get install -y libcairo2 libcairo2-dev 
-RUN python3.8 -m pip install --ignore-installed pycairo 
-
-RUN python3.8 -m pip install opencv-python boto3
+RUN python3.8 -m pip install --ignore-installed pycairo==1.23.0
+RUN python3.8 -m pip install opencv-python==4.7.0.72 boto3==1.26.152
 
 RUN apt-get update -y && apt-get -y install libgirepository1.0-dev
-RUN python3.8 -m pip install --ignore-installed PyGObject
 
 RUN apt-get update && \
 	apt-get install -y \
@@ -43,8 +41,9 @@ RUN apt-get update && \
 	vim \
 	ninja-build
 
+RUN python3.8 -m pip install --ignore-installed PyGObject==3.44.2
 WORKDIR /opt/
-RUN	git clone https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp.git
+RUN	git clone https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp.git --branch v3.4.1
 WORKDIR /opt/amazon-kinesis-video-streams-producer-sdk-cpp/build/
 RUN cmake -G "Ninja" .. -DBUILD_GSTREAMER_PLUGIN=ON -DBUILD_DEPENDENCIES=OFF -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON && \
 	ninja

--- a/samples/kinesis_video_streams/kinesis_video_streams_app/packages/201125699002-kinesis_video_streams_code-1.0/src/app.py
+++ b/samples/kinesis_video_streams/kinesis_video_streams_app/packages/201125699002-kinesis_video_streams_code-1.0/src/app.py
@@ -1,25 +1,22 @@
-import json
 import logging
-import time
 import os
 import re
 from logging.handlers import RotatingFileHandler
 
 import boto3
-from botocore.exceptions import ClientError
 import cv2
-import numpy as np
+import gi
 import panoramasdk
 
-import gi
-gi.require_version('Gst', '1.0')
-from gi.repository import Gst, GObject
+gi.require_version("Gst", "1.0")
+from gi.repository import Gst
 
-#GST Environment Variables
-os.environ['GST_PLUGIN_PATH'] = '/opt/amazon-kinesis-video-streams-producer-sdk-cpp/build'
-os.environ['LD_LIBRARY_PATH'] = '/opt/amazon-kinesis-video-streams-producer-sdk-cpp/open-source/local/lib'
+# GST Environment Variables
+os.environ["GST_PLUGIN_PATH"] = "/opt/amazon-kinesis-video-streams-producer-sdk-cpp/build"
+os.environ["LD_LIBRARY_PATH"] = "/opt/amazon-kinesis-video-streams-producer-sdk-cpp/open-source/local/lib"
 
 Gst.init(None)
+
 
 class Application(panoramasdk.node):
     def __init__(self):
@@ -27,39 +24,45 @@ class Application(panoramasdk.node):
         self.kvs_stream_name = self.inputs.kvs_stream_name.get()
         self.role_alias = self.inputs.iot_role_alias.get()
         self.kvs_region = self.inputs.kvs_region.get()
-        self.root_ca = '/panorama/certs/cacert.pem'
+        self.root_ca = "/panorama/certs/cacert.pem"
         self.kvs_pipeline = {}
         self.app_src = {}
+        self.kvs_width = 1280
+        self.kvs_height = 720
+        self.kvs_frame_rate = "15/1"
 
-        logger.info(' ---- Parameters---- ')
+        logger.info(" ---- Parameters---- ")
         logger.info(self.kvs_stream_name)
         logger.info(self.role_alias)
         logger.info(self.kvs_region)
-        logger.info(' ++++ Parameters++++ ')
+        logger.info(" ++++ Parameters++++ ")
 
         try:
-            iot_client = boto3.client('iot',region_name=self.kvs_region)
-            self.endpoint = iot_client.describe_endpoint(endpointType='iot:CredentialProvider')['endpointAddress']
+            iot_client = boto3.client("iot", region_name=self.kvs_region)
+            self.endpoint = iot_client.describe_endpoint(endpointType="iot:CredentialProvider")["endpointAddress"]
         except:
-            logger.exception('Error on getting IoT credential endpoint.')
+            logger.exception("Error on getting IoT credential endpoint.")
 
         self.cameras = list(self.kvs_stream_name.split(","))
 
         for camera in self.cameras:
             # Parse Gstreamer appsrc pipeline and hook with camera name as appsrc name
-            iot_cert = f'/panorama/certs/{camera}-cert.pem'
-            iot_key = f'/panorama/certs/{camera}-private.key'
+            iot_cert = f"/panorama/certs/{camera}-cert.pem"
+            iot_key = f"/panorama/certs/{camera}-private.key"
 
-            pipe = f"appsrc name={camera} is-live=true block=true format=GST_FORMAT_TIME do-timestamp=TRUE " \
-                f" caps=video/x-raw,format=BGR,width=1280,height=720,framerate=15/1 " \
-                f"! videoconvert ! x264enc ! video/x-h264,stream-format=(string)byte-stream ! h264parse " \
-                f"! kvssink stream-name={camera} storage-size=512 " \
-                f" iot-certificate=\"iot-certificate,endpoint={self.endpoint}," \
-                f"cert-path={iot_cert}," \
-                f"key-path={iot_key}," \
-                f"ca-path={self.root_ca}," \
-                f"role-aliases={self.role_alias}\" " \
+            pipe = (
+                f"appsrc name={camera} is-live=true block=true format=GST_FORMAT_TIME do-timestamp=TRUE ! "
+                f"video/x-raw,format=BGR,width={self.kvs_width},height={self.kvs_height},framerate={self.kvs_frame_rate} ! "
+                f"videoconvert ! "
+                "x264enc ! video/x-h264,stream-format=avc,alignment=au,profile=baseline ! h264parse ! "
+                f"kvssink stream-name={camera} storage-size=512 "
+                f'iot-certificate="iot-certificate,endpoint={self.endpoint},'
+                f"cert-path={iot_cert},"
+                f"key-path={iot_key},"
+                f"ca-path={self.root_ca},"
+                f'role-aliases={self.role_alias}" '
                 f"aws-region={self.kvs_region}"
+            )
 
             self.kvs_pipeline[camera] = Gst.parse_launch(pipe)
             self.app_src[camera] = self.kvs_pipeline[camera].get_by_name(camera)
@@ -71,37 +74,41 @@ class Application(panoramasdk.node):
         data = frame.tobytes()
         buf = Gst.Buffer.new_wrapped(data)
         buf.duration = Gst.CLOCK_TIME_NONE
-        timestamp = Gst.CLOCK_TIME_NONE
         buf.pts = buf.dts = Gst.CLOCK_TIME_NONE
         buf.offset = Gst.BUFFER_OFFSET_NONE
-        src.emit('push-buffer', buf)
+        src.emit("push-buffer", buf)
 
     def process_streams(self):
         """Processes one frame of video from one or more video streams."""
         while True:
-        # Loop through attached video streams
+            # Loop through attached video streams
             streams = self.inputs.video_in.get()
             for stream in streams:
-                
+
                 # media.stream_id can contain UUID at the end. Remove it.
                 stream_name = stream.stream_id
-                re_result = re.fullmatch( "(.*)([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})", stream_name )
+                re_result = re.fullmatch(
+                    "(.*)([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})", stream_name
+                )
                 if re_result is not None:
                     stream_name = re_result.group(1)
-                
-                self.push_to_pipeline(self.app_src[stream_name], stream.image)
+                # Resize the image to 720p for kvs output size. Please change the size depends
+                # on your own business logic
+                img = cv2.resize(stream.image, (self.kvs_width, self.kvs_height))
+                self.push_to_pipeline(self.app_src[stream_name], img)
 
             self.outputs.video_out.put(streams)
 
-def get_logger(name=__name__,level=logging.INFO):
+
+def get_logger(name=__name__, level=logging.INFO):
     logger = logging.getLogger(name)
     logger.setLevel(level)
     handler = RotatingFileHandler("/opt/aws/panorama/logs/app.log", maxBytes=100000000, backupCount=2)
-    formatter = logging.Formatter(fmt='%(asctime)s %(levelname)-8s %(message)s',
-                                    datefmt='%Y-%m-%d %H:%M:%S')
+    formatter = logging.Formatter(fmt="%(asctime)s %(levelname)-8s %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
     handler.setFormatter(formatter)
     logger.addHandler(handler)
     return logger
+
 
 def main():
     try:
@@ -109,8 +116,9 @@ def main():
         app = Application()
         logger.info("PROCESSING STREAMS")
         app.process_streams()
-    except:
-        logger.exception('Exception during processing loop.')
+    except Exception as e:
+        logger.exception(f"Exception during processing loop: {e}")
+
 
 logger = get_logger(level=logging.INFO)
 main()


### PR DESCRIPTION
*Issue #, if available:*

After we update the python version to 3.8, the default PyGObject installed is 3.46.0. However, in our base image the glib is too old to support 3.46.0.

*Description of changes:*

- Downgrade the PyGObject to 3.44.2
- Fixed all python library version.
- Fixed the KVS amazon-kinesis-video-streams-producer-sdk-cpp version to v3.4.1
- Slightly modify the readme and the code to support various of RTSP resolution. By default we will resize the source to 720p and send it to KVS.
- Some code formatting.

Have deployed the app and tested it. I am able to see my RTSP stream on the KVS console.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
